### PR TITLE
fix(selection): correct snapshot mark rendering and comment ownership

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/Article/BookmarkArticle.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/BookmarkArticle.vue
@@ -311,43 +311,48 @@ defineExpose({
     transition: all var(--slax-dur-normal);
   }
 
+  // !important 压制插件注入的 CSS
+  // 否则划线样式被插件覆盖
   &:deep(slax-mark.stroke) {
     cursor: pointer;
-    text-decoration: underline solid;
-    text-decoration-color: color-mix(in srgb, var(--slax-accent) 50%, transparent);
-    text-decoration-thickness: 1.5px;
-    text-underline-offset: 6px;
+    text-decoration: underline solid !important;
+    text-decoration-color: color-mix(in srgb, var(--slax-accent) 50%, transparent) !important;
+    text-decoration-thickness: 1.5px !important;
+    text-underline-offset: 6px !important;
     box-decoration-break: clone;
+    border-bottom: none !important;
   }
 
   &:deep(slax-mark.self-stroke) {
     cursor: pointer;
-    text-decoration: underline solid;
-    text-decoration-color: color-mix(in srgb, var(--slax-accent) 75%, transparent);
-    text-decoration-thickness: 1.5px;
-    text-underline-offset: 6px;
+    text-decoration: underline solid !important;
+    text-decoration-color: color-mix(in srgb, var(--slax-accent) 50%, transparent) !important;
+    text-decoration-thickness: 1.5px !important;
+    text-underline-offset: 6px !important;
     box-decoration-break: clone;
+    border-bottom: none !important;
   }
 
   &:deep(slax-mark.comment) {
     cursor: pointer;
-    text-decoration: underline dashed;
-    text-decoration-color: color-mix(in srgb, var(--slax-accent) 50%, transparent);
-    text-decoration-thickness: 1.5px;
-    text-underline-offset: 6px;
+    text-decoration: underline solid !important;
+    text-decoration-color: color-mix(in srgb, var(--slax-accent) 50%, transparent) !important;
+    text-decoration-thickness: 1.5px !important;
+    text-underline-offset: 6px !important;
     box-decoration-break: clone;
+    border-bottom: none !important;
   }
 
   // 同一处既有划线又有评论时，划线（实线）样式覆盖评论（虚线）——对齐 demo「划线和评论都用实线」。
   // 多一个 class 把特异性抬过上面的 .comment，且本规则在后，双重保证生效。
   &:deep(slax-mark.comment.stroke) {
-    text-decoration: underline solid;
-    text-decoration-color: color-mix(in srgb, var(--slax-accent) 50%, transparent);
+    text-decoration: underline solid !important;
+    text-decoration-color: color-mix(in srgb, var(--slax-accent) 50%, transparent) !important;
   }
 
   &:deep(slax-mark.comment.self-stroke) {
-    text-decoration: underline solid;
-    text-decoration-color: color-mix(in srgb, var(--slax-accent) 75%, transparent);
+    text-decoration: underline solid !important;
+    text-decoration-color: color-mix(in srgb, var(--slax-accent) 50%, transparent) !important;
   }
 
   &:deep(slax-mark:hover) {
@@ -361,7 +366,7 @@ defineExpose({
 
   &:deep(slax-mark:has(img).stroke),
   &:deep(slax-mark:has(img).comment) {
-    border: 1.5px solid var(--slax-accent);
+    border: 1.5px solid var(--slax-accent) !important;
     text-decoration: none;
   }
 

--- a/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotAIPanel.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotAIPanel.vue
@@ -94,19 +94,73 @@ const processOutlineAnchors = (text: string): string => {
   return text
 }
 
-const handleAnchorClick = (link: string) => {
+// 找最近可滚动祖先，无则回退 window
+const getScrollParent = (el: HTMLElement): HTMLElement | null => {
+  let parent = el.parentElement
+  while (parent) {
+    const { overflowY } = getComputedStyle(parent)
+    if ((overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') && parent.scrollHeight > parent.clientHeight) {
+      return parent
+    }
+    parent = parent.parentElement
+  }
+  return null
+}
+
+// 固定 360ms 平滑滚动并居中
+// 原生 smooth 太慢会错过高亮
+const smoothScrollToCenter = (el: HTMLElement, duration = 360): Promise<void> => {
+  return new Promise(resolve => {
+    const scroller = getScrollParent(el)
+    const isWindow = !scroller
+    const viewportH = isWindow ? window.innerHeight : scroller!.clientHeight
+    const scrollHeight = isWindow ? document.documentElement.scrollHeight : scroller!.scrollHeight
+    const startTop = isWindow ? window.scrollY : scroller!.scrollTop
+
+    const elRect = el.getBoundingClientRect()
+    const baseTop = isWindow ? elRect.top + window.scrollY : startTop + (elRect.top - scroller!.getBoundingClientRect().top)
+    const maxTop = Math.max(0, scrollHeight - viewportH)
+    const targetTop = Math.max(0, Math.min(baseTop - viewportH / 2 + elRect.height / 2, maxTop))
+
+    const distance = targetTop - startTop
+    if (Math.abs(distance) < 1) {
+      resolve()
+      return
+    }
+
+    const easeInOutCubic = (t: number) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2)
+    let startTime: number | null = null
+    const step = (now: number) => {
+      if (startTime === null) startTime = now
+      const progress = Math.min((now - startTime) / duration, 1)
+      const top = startTop + distance * easeInOutCubic(progress)
+      if (isWindow) {
+        window.scrollTo(0, top)
+      } else {
+        scroller!.scrollTop = top
+      }
+      if (progress < 1) {
+        requestAnimationFrame(step)
+      } else {
+        resolve()
+      }
+    }
+    requestAnimationFrame(step)
+  })
+}
+
+const handleAnchorClick = async (link: string) => {
   const refText = anchorRefs[link]
   if (!refText) return
-  // 在详情页正文区域查找并滚动到对应文本，滚动后高亮闪烁
+  // 在正文区查找目标文本
   const contentEl = document.querySelector('.bookmark-detail .detail') || document.body
   const result = findMatchingElement(refText, contentEl)
   if (result?.element) {
-    result.element.scrollIntoView({ behavior: 'smooth', block: 'center' })
-    // 高亮闪烁：复用 hl-flash 动画类（BookmarkArticle 定义在 slax-mark 上，
-    // 这里给普通元素加 anchor-flash 类，由本组件的 :global keyframes 驱动）
-    const el = result.element
+    const el = result.element as HTMLElement
+    // 先滚到位再高亮，确保可见
+    await smoothScrollToCenter(el)
     el.classList.remove('anchor-flash')
-    void el.offsetWidth // 强制 reflow，确保 animation 重新触发
+    void el.offsetWidth // 强制 reflow 重触发动画
     el.classList.add('anchor-flash')
     setTimeout(() => el.classList.remove('anchor-flash'), 3000)
   }

--- a/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotChatPanel.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotChatPanel.vue
@@ -16,11 +16,6 @@
         </div>
         <div class="chat-empty-title">{{ $t('component.snapshot_chat.empty_title') }}</div>
         <div class="chat-empty-desc">{{ $t('component.snapshot_chat.empty_desc') }}</div>
-        <div class="chat-suggestions">
-          <button v-for="key in SUGGESTIONS" :key="key" class="chat-suggestion-pill" @click="sendMessage(t(key))">
-            {{ t(key) }}
-          </button>
-        </div>
       </div>
 
       <!-- 消息列表 -->
@@ -151,9 +146,6 @@ const emits = defineEmits<{
   dismiss: []
   findQuote: [quote: QuoteData]
 }>()
-
-// 建议问题（硬编码 i18n key）
-const SUGGESTIONS = ['component.snapshot_chat.suggestion_1', 'component.snapshot_chat.suggestion_2', 'component.snapshot_chat.suggestion_3']
 
 const botParams: ChatBotParams = (() => {
   if (props.bookmarkId) {
@@ -730,10 +722,15 @@ defineExpose({ addQuoteData, focusTextarea })
     }
   }
 
-  // 空态（对齐 snapshot demo：text-align center + 图标 margin auto，不用 flex 居中）
+  // 空态：引导内容整体居中
   .chat-empty {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
     text-align: center;
-    padding: 72px 8px 24px;
+    padding: 24px 8px;
     color: var(--slax-text-light);
 
     .chat-empty-icon {
@@ -758,33 +755,6 @@ defineExpose({ addQuoteData, focusTextarea })
       font-size: 13px;
       color: var(--slax-text-muted);
       line-height: 1.6;
-      // demo 中 title/desc 是一个 <p> 带 <br>，整体下边距 28px；此处拆两行，下边距落在 desc 上
-      margin-bottom: 28px;
-    }
-
-    .chat-suggestions {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-      align-items: center;
-
-      .chat-suggestion-pill {
-        font-size: 12px;
-        color: var(--slax-text-muted);
-        background: var(--slax-bg);
-        border: 1px solid var(--slax-border);
-        border-radius: 999px;
-        padding: 7px 14px;
-        line-height: 1.4;
-        cursor: pointer;
-        transition: all 0.15s;
-
-        &:hover {
-          color: var(--slax-accent);
-          border-color: color-mix(in srgb, var(--slax-accent) 40%, var(--slax-border));
-          background: var(--slax-accent-bg);
-        }
-      }
     }
   }
 

--- a/apps/slax-reader-dweb/layers/core/styles/mark.css
+++ b/apps/slax-reader-dweb/layers/core/styles/mark.css
@@ -5,31 +5,36 @@ slax-mark {
   transition: all var(--slax-dur-normal);
 }
 
+/* !important 压制插件注入的 CSS
+   否则划线样式被插件覆盖 */
 slax-mark.stroke {
   cursor: pointer;
-  text-decoration: underline solid;
-  text-decoration-color: color-mix(in srgb, var(--slax-accent) 50%, transparent);
-  text-decoration-thickness: 1.5px;
-  text-underline-offset: 6px;
+  text-decoration: underline solid !important;
+  text-decoration-color: color-mix(in srgb, var(--slax-accent) 50%, transparent) !important;
+  text-decoration-thickness: 1.5px !important;
+  text-underline-offset: 6px !important;
   box-decoration-break: clone;
+  border-bottom: none !important;
 }
 
 slax-mark.self-stroke {
   cursor: pointer;
-  text-decoration: underline solid;
-  text-decoration-color: color-mix(in srgb, var(--slax-accent) 75%, transparent);
-  text-decoration-thickness: 1.5px;
-  text-underline-offset: 6px;
+  text-decoration: underline solid !important;
+  text-decoration-color: color-mix(in srgb, var(--slax-accent) 50%, transparent) !important;
+  text-decoration-thickness: 1.5px !important;
+  text-underline-offset: 6px !important;
   box-decoration-break: clone;
+  border-bottom: none !important;
 }
 
 slax-mark.comment {
   cursor: pointer;
-  text-decoration: underline dashed;
-  text-decoration-color: color-mix(in srgb, var(--slax-accent) 50%, transparent);
-  text-decoration-thickness: 1.5px;
-  text-underline-offset: 6px;
+  text-decoration: underline solid !important;
+  text-decoration-color: color-mix(in srgb, var(--slax-accent) 50%, transparent) !important;
+  text-decoration-thickness: 1.5px !important;
+  text-underline-offset: 6px !important;
   box-decoration-break: clone;
+  border-bottom: none !important;
 }
 
 slax-mark:hover {
@@ -50,7 +55,7 @@ slax-mark:has(img) {
 slax-mark:has(img).stroke,
 slax-mark:has(img).comment {
   border: 1.5px solid var(--slax-accent) !important;
-  text-decoration: none;
+  text-decoration: none !important;
 }
 
 slax-mark:has(img)::after {

--- a/commons/selection/src/core/MarkManager.ts
+++ b/commons/selection/src/core/MarkManager.ts
@@ -98,6 +98,8 @@ export interface MarkManagerDependencies {
  */
 export class MarkManager extends Base {
   private _markItemInfos: Ref<MarkItemInfo[]>
+  // 重绘代际：新重绘作废进行中的旧重绘
+  private _drawGeneration = 0
   private _currentMarkItemInfo: Ref<MarkItemInfo | null>
   private _selectContent: Ref<MarkSelectContent[]>
   private _findQuote: (quote: QuoteData) => void
@@ -160,11 +162,16 @@ export class MarkManager extends Base {
    * @param marks 标记详情数据
    */
   async drawMarks(marks: MarkDetail) {
+    // 重绘前清旧标记，避免重复与残留
+    const gen = ++this._drawGeneration
+    this.renderer.clearAllMarks()
     const userMap = this.createUserMap(marks.user_list)
     const commentMap = this.buildCommentMap(marks.mark_list, userMap)
     this.buildCommentRelationships(marks.mark_list, commentMap)
-    this._markItemInfos.value = this.generateMarkItemInfos(marks.mark_list, commentMap)
-    for (const info of this._markItemInfos.value) {
+    const infos = (this._markItemInfos.value = this.generateMarkItemInfos(marks.mark_list, commentMap))
+    for (const info of infos) {
+      // 有更新的重绘则中止
+      if (gen !== this._drawGeneration) return
       await this.renderer.drawMark(info)
     }
   }
@@ -801,7 +808,9 @@ export class MarkManager extends Base {
       }
     }
 
-    return infoItems
+    // 剔除空 info（已删标记残留）
+    // 否则会画出无 class 的残留
+    return infoItems.filter(info => info.stroke.length > 0 || info.comments.length > 0)
   }
 
   /**

--- a/commons/selection/src/core/MarkRenderer.ts
+++ b/commons/selection/src/core/MarkRenderer.ts
@@ -57,8 +57,8 @@ export class MarkRenderer extends Base {
         drawMark = infos.length > 0
       }
 
-      // 如果无法精确绘制，尝试使用近似匹配
-      if (!drawMark && info.approx) {
+      // 近似匹配兜底；空标记不画
+      if (!drawMark && info.approx && (isStroke || isComment)) {
         const rangeSvc = new HighlightRange(this.document, this.config.monitorDom!)
         const newRange = rangeSvc.getRange(info.approx)
         if (newRange) {
@@ -83,6 +83,19 @@ export class MarkRenderer extends Base {
     }
 
     return info.id
+  }
+
+  /**
+   * 清除已绘制标记，重绘前调用
+   * 保留临时高亮 data-uuid="0"
+   */
+  clearAllMarks() {
+    // 限本容器，避免误删其他实例
+    const root: ParentNode & Node = this.config.containerDom ?? this.document
+    for (const mark of Array.from(root.querySelectorAll('slax-mark[data-uuid]'))) {
+      if (mark.getAttribute('data-uuid') !== '0') removeOuterTag(mark)
+    }
+    root.normalize()
   }
 
   /**


### PR DESCRIPTION
- generateMarkItemInfos: drop empty infos left by deleted marks, which were otherwise drawn as class-less <slax-mark> via the approx fallback
- MarkRenderer: skip the approx fallback when a mark has no stroke/comment
- MarkManager.drawMarks: clear existing marks before redraw (scoped to the container) and guard interleaved redraws with a generation token, so a live create-then-delete no longer leaves a stale highlight
- mark styles: use !important to override the browser extension's injected mark CSS