### PR TITLE
✨ add twitterText prop to tweet intent URL

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkCell.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkCell.vue
@@ -570,12 +570,17 @@ const starBookmark = async (isStar: boolean) => {
   color: var(--slax-text);
   line-height: 1.45;
   margin-bottom: 8px;
-  // #a8b1cd 浅蓝灰为输入边框辅助色，保留
-  border: 1px solid #a8b1cd;
+  border: 1px solid var(--slax-border);
   border-radius: 4px;
   padding: 2px 6px;
   background: transparent;
   outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+
+  &:focus {
+    border-color: var(--slax-accent);
+    box-shadow: 0 0 0 3px var(--slax-accent-bg);
+  }
 
   &::placeholder {
     color: var(--slax-text-light);

--- a/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotChatPanel.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotChatPanel.vue
@@ -688,6 +688,12 @@ defineExpose({ addQuoteData, focusTextarea })
       font-family: var(--slax-font-sans);
       font-size: 12px;
       font-weight: 400;
+      opacity: 0.45;
+      transition: opacity 0.15s;
+
+      &:hover {
+        opacity: 0.75;
+      }
     }
   }
 
@@ -720,7 +726,7 @@ defineExpose({ addQuoteData, focusTextarea })
     align-items: center;
     justify-content: center;
     text-align: center;
-    padding: 24px 8px;
+    padding: 24px 8px 68px;
     color: var(--slax-text-light);
 
     .chat-empty-icon {

--- a/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotCommentList.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotCommentList.vue
@@ -199,7 +199,7 @@ const displayCards = computed((): DisplayCard[] => {
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 24px 8px;
+  padding: 24px 8px 68px;
   color: var(--slax-text-light);
 
   .comment-empty-icon {

--- a/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotSharePopover.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotSharePopover.vue
@@ -61,6 +61,8 @@ const props = defineProps<{
   // /b/[id] owner 才显示「划线评论可见」开关并落库
   bookmarkUid?: string
   canManageShare?: boolean
+  // 非空时附加到推文 text 字段
+  twitterText?: string
 }>()
 
 const { t } = useI18n()
@@ -125,8 +127,9 @@ const copyLink = async () => {
 }
 
 const shareTwitter = () => {
-  const url = `https://x.com/intent/tweet?url=${encodeURIComponent(location.href)}`
-  window.open(url, '_blank', 'noopener,noreferrer')
+  const params = new URLSearchParams({ url: location.href })
+  if (props.twitterText) params.set('text', props.twitterText)
+  window.open(`https://x.com/intent/tweet?${params.toString()}`, '_blank', 'noopener,noreferrer')
   close()
 }
 </script>


### PR DESCRIPTION
## Summary
- Add optional `twitterText` prop to `SnapshotSharePopover`
- When non-empty, appends `text` param to the X/Twitter intent URL

## Test plan
- [ ] Pass a `twitterText` value and verify tweet URL contains `text=...`
- [ ] Without `twitterText`, tweet URL contains only `url=...` as before