### PR TITLE
✨ show selection menu when clicking existing mark

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/ArticleSelectionMenus.ce.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/ArticleSelectionMenus.ce.vue
@@ -59,6 +59,11 @@ const props = defineProps({
   isStroked: {
     type: Boolean,
     required: false
+  },
+  // 本人已评论该划线时隐藏「评论」项
+  hideComment: {
+    type: Boolean,
+    required: false
   }
 })
 const emits = defineEmits(['action', 'dismiss', 'noAction'])
@@ -92,13 +97,16 @@ const updateMenus = () => {
             id: MenuType.Stroke,
             name: t('common.operate.line'),
             icon: ICON_STROKE
-          },
-      {
+          }
+    )
+    // 本人未评论过才显「评论」
+    if (!props.hideComment) {
+      menus.value.push({
         id: MenuType.Comment,
         name: t('common.operate.comment'),
         icon: ICON_COMMENT
-      }
-    )
+      })
+    }
   }
 
   if (props.allowChatbot) {
@@ -130,7 +138,7 @@ const handleClickOutside = () => {
 }
 
 watch(
-  () => [props.allowAction, props.allowChatbot, props.isStroked],
+  () => [props.allowAction, props.allowChatbot, props.isStroked, props.hideComment],
   () => {
     updateMenus()
   },

--- a/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/DwebArticleSelection.ts
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/DwebArticleSelection.ts
@@ -4,7 +4,7 @@ import type { MarkModal } from './modal'
 import { getUUID } from './tools'
 import { ArticleSelection as BaseArticleSelection, type IMarkModal } from '@slax-reader/selection'
 import type { IUserProvider, SelectionDependencies } from '@slax-reader/selection/adapters'
-import type { MarkCommentInfo, MarkItemInfo, MarkPathItem, MarkSelectContent, MenuType, QuoteData, SelectionConfig, SelectTextInfo } from '@slax-reader/selection/types'
+import type { MarkItemInfo, MarkPathItem, MarkSelectContent, MenuType, QuoteData, SelectionConfig, SelectTextInfo } from '@slax-reader/selection/types'
 
 /**
  * Dweb端ArticleSelection扩展
@@ -313,13 +313,11 @@ export class DwebArticleSelection extends BaseArticleSelection {
     })
   }
 
-  /** 本人是否已对该划线评论过（含子回复） */
+  /** 本人是否已对该划线发过根评论 */
   private hasOwnComment(info: MarkItemInfo): boolean {
     const userId = this.userProvider.getUserId()
     if (!userId) return false
-    const hit = (list: MarkCommentInfo[]): boolean =>
-      list.some(c => (c.userId === userId && !c.isDeleted) || hit(c.children ?? []))
-    return hit(info.comments)
+    return info.comments.some(c => c.userId === userId && !c.isDeleted)
   }
 
   /**

--- a/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/DwebArticleSelection.ts
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/DwebArticleSelection.ts
@@ -41,8 +41,8 @@ export class DwebArticleSelection extends BaseArticleSelection {
     this.manager.updateCurrentMarkItemInfo(infoItem)
     this.manager.showPanel()
 
-    // 纯评论或访客：不弹菜单
-    if (infoItem.stroke.length === 0 || !this.config.allowAction) return
+    // 访客不可操作：不弹菜单
+    if (!this.config.allowAction) return
 
     // 延后到 click 结束再弹，
     // 避开 click-outside 与重复 mouseup
@@ -317,9 +317,12 @@ export class DwebArticleSelection extends BaseArticleSelection {
     let menusY = 0
     this.modal.showMenus({
       event: e,
-      isStroked: true,
+      // 有划线才显「删除划线」，否则显「划线」
+      isStroked: info.stroke.length > 0,
       callback: (type: MenuType, event: MouseEvent) => {
-        if (type === ('stroke_delete' as MenuType)) {
+        if (type === ('stroke' as MenuType)) {
+          this.manager.strokeSelection({ info })
+        } else if (type === ('stroke_delete' as MenuType)) {
           this.manager.deleteStroke(info)
         } else if (type === ('copy' as MenuType)) {
           this.manager.copyMarkedText({ source: info.source, approx: info.approx, event })

--- a/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/DwebArticleSelection.ts
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/DwebArticleSelection.ts
@@ -21,6 +21,56 @@ export class DwebArticleSelection extends BaseArticleSelection {
   constructor(config: SelectionConfig, dependencies: SelectionDependencies, modal: IMarkModal) {
     super(config, dependencies, modal)
     this.modal = modal
+    // 点击已有划线时弹出选区菜单
+    this.renderer.setMarkClickHandler(this.handleExistingMarkClick.bind(this))
+  }
+
+  /**
+   * 点击已有划线：保留原侧栏逻辑，
+   * 本人可操作的划线再加弹菜单
+   */
+  private handleExistingMarkClick(ele: HTMLElement, event: PointerEvent) {
+    const markEl = (ele.closest?.('slax-mark') as HTMLElement | null) ?? ele
+    const id = markEl?.dataset.uuid
+    if (!id || id === '0') return
+
+    const infoItem = this.markItemInfos.value.find(item => item.id === id)
+    if (!infoItem) return
+
+    // 原逻辑：打开评论侧栏
+    this.manager.updateCurrentMarkItemInfo(infoItem)
+    this.manager.showPanel()
+
+    // 纯评论或访客：不弹菜单
+    if (infoItem.stroke.length === 0 || !this.config.allowAction) return
+
+    // 延后到 click 结束再弹，
+    // 避开 click-outside 与重复 mouseup
+    setTimeout(() => {
+      const range = this.selectMarkContents(id)
+      if (!range) return
+      this.rememberMenuSelection(range)
+      this.showExistingMarkMenus(event, infoItem)
+    }, 0)
+  }
+
+  /** 选中该条划线全部分段，供菜单定位 */
+  private selectMarkContents(id: string): Range | null {
+    const root: ParentNode = this.config.monitorDom ?? this.document
+    const marks = Array.from(root.querySelectorAll(`slax-mark[data-uuid="${id}"]`)) as HTMLElement[]
+    const first = marks[0]
+    const last = marks[marks.length - 1]
+    if (!first || !last) return null
+
+    const range = first.ownerDocument.createRange()
+    range.setStartBefore(first)
+    range.setEndAfter(last)
+
+    const selection = this.getSelection()
+    if (!selection) return null
+    selection.removeAllRanges()
+    selection.addRange(range)
+    return range
   }
 
   // 选区与上次一致即视为重复，跳过

--- a/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/DwebArticleSelection.ts
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/DwebArticleSelection.ts
@@ -1,9 +1,10 @@
 import { getElementFullSelector } from '@commons/utils/dom'
 
+import type { MarkModal } from './modal'
 import { getUUID } from './tools'
 import { ArticleSelection as BaseArticleSelection, type IMarkModal } from '@slax-reader/selection'
-import type { SelectionDependencies } from '@slax-reader/selection/adapters'
-import type { MarkItemInfo, MarkPathItem, MarkSelectContent, MenuType, QuoteData, SelectionConfig, SelectTextInfo } from '@slax-reader/selection/types'
+import type { IUserProvider, SelectionDependencies } from '@slax-reader/selection/adapters'
+import type { MarkCommentInfo, MarkItemInfo, MarkPathItem, MarkSelectContent, MenuType, QuoteData, SelectionConfig, SelectTextInfo } from '@slax-reader/selection/types'
 
 /**
  * Dweb端ArticleSelection扩展
@@ -11,7 +12,9 @@ import type { MarkItemInfo, MarkPathItem, MarkSelectContent, MenuType, QuoteData
  * 继承自commons/selection的基础实现，添加dweb特定的业务逻辑
  */
 export class DwebArticleSelection extends BaseArticleSelection {
-  private modal: IMarkModal
+  // 用 MarkModal 具体类型，showMenus 支持 hideComment 扩展项
+  private modal: MarkModal
+  private userProvider: IUserProvider
 
   // 上次弹菜单的目标（选区/图片）
   // 用于跳过滚动等重复 touchend
@@ -20,7 +23,8 @@ export class DwebArticleSelection extends BaseArticleSelection {
 
   constructor(config: SelectionConfig, dependencies: SelectionDependencies, modal: IMarkModal) {
     super(config, dependencies, modal)
-    this.modal = modal
+    this.modal = modal as MarkModal
+    this.userProvider = dependencies.userProvider
     // 点击已有划线时弹出选区菜单
     this.renderer.setMarkClickHandler(this.handleExistingMarkClick.bind(this))
   }
@@ -309,6 +313,15 @@ export class DwebArticleSelection extends BaseArticleSelection {
     })
   }
 
+  /** 本人是否已对该划线评论过（含子回复） */
+  private hasOwnComment(info: MarkItemInfo): boolean {
+    const userId = this.userProvider.getUserId()
+    if (!userId) return false
+    const hit = (list: MarkCommentInfo[]): boolean =>
+      list.some(c => (c.userId === userId && !c.isDeleted) || hit(c.children ?? []))
+    return hit(info.comments)
+  }
+
   /**
    * 精确命中已有划线时的选区菜单：复制 / 删除划线 / 评论 / Chat。
    * 与新选区菜单（handleMouseUp 内联块）分开，避免误改已存在标记的 id 语义。
@@ -319,6 +332,8 @@ export class DwebArticleSelection extends BaseArticleSelection {
       event: e,
       // 有划线才显「删除划线」，否则显「划线」
       isStroked: info.stroke.length > 0,
+      // 本人已评论过该划线则隐藏「评论」
+      hideComment: this.hasOwnComment(info),
       callback: (type: MenuType, event: MouseEvent) => {
         if (type === ('stroke' as MenuType)) {
           this.manager.strokeSelection({ info })

--- a/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/modal.ts
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/modal.ts
@@ -72,11 +72,13 @@ export class MarkModal extends Base implements IMarkModal {
   showMenus = (options: {
     event: MouseEvent | TouchEvent
     isStroked?: boolean
+    // 本人已评论该划线时隐藏「评论」项
+    hideComment?: boolean
     callback?: (type: MenuType, event: MouseEvent) => void
     positionCallback?: (position: { x: number; y: number }) => void
     noActionCallback?: () => void
   }) => {
-    const { event, isStroked, callback, positionCallback, noActionCallback } = options
+    const { event, isStroked, hideComment, callback, positionCallback, noActionCallback } = options
     const { containerDom, allowAction, allowChatbot } = this.config
 
     if (!containerDom || this.isPanelExist(containerDom)) {
@@ -130,7 +132,8 @@ export class MarkModal extends Base implements IMarkModal {
       allowAction,
       allowChatbot: allowChatbot ?? true,
       dark: !!isInIframe,
-      isStroked: !!isStroked
+      isStroked: !!isStroked,
+      hideComment: !!hideComment
     })
 
     const onDismiss = () => {

--- a/apps/slax-reader-dweb/tests/unit/components/Article/Selection/DwebArticleSelection.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/Article/Selection/DwebArticleSelection.spec.ts
@@ -181,7 +181,7 @@ describe('DwebArticleSelection', () => {
       expect(mockManager.showPanel).not.toHaveBeenCalled()
     })
 
-    it('纯评论（无 stroke）：updateCurrentMarkItemInfo + showPanel，不弹菜单', () => {
+    it('纯评论（无 stroke）：showPanel + 弹菜单（isStroked=false）', async () => {
       const config = buildConfig()
       const modal = buildModal()
       const info = { id: 'c1', source: [], comments: [{ markUid: 'x' }], stroke: [] }
@@ -191,9 +191,11 @@ describe('DwebArticleSelection', () => {
       const mark = makeMark('c1', config)
 
       handler(mark, new MouseEvent('click') as PointerEvent)
+      await vi.runAllTimersAsync()
       expect(mockManager.updateCurrentMarkItemInfo).toHaveBeenCalledWith(info)
       expect(mockManager.showPanel).toHaveBeenCalled()
-      expect(modal.showMenus).not.toHaveBeenCalled()
+      expect(modal.showMenus).toHaveBeenCalledTimes(1)
+      expect(modal.showMenus.mock.calls[0]![0]).toMatchObject({ isStroked: false })
     })
 
     it('不可操作（allowAction=false）：即便有 stroke 也退回 showPanel', () => {

--- a/apps/slax-reader-dweb/tests/unit/components/Article/Selection/DwebArticleSelection.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/Article/Selection/DwebArticleSelection.spec.ts
@@ -38,7 +38,8 @@ const mockRenderer = {
   getAllTextNodes: vi.fn((): Node[] => []),
   transferNodeInfos: vi.fn(),
   addImageMark: vi.fn(),
-  addMark: vi.fn()
+  addMark: vi.fn(),
+  setMarkClickHandler: vi.fn()
 }
 
 vi.mock('@slax-reader/selection', () => {
@@ -139,6 +140,106 @@ describe('DwebArticleSelection', () => {
       expect(inst).toBeInstanceOf(DwebArticleSelection)
       // private modal 通过类型转换访问
       expect((inst as unknown as { modal: ReturnType<typeof buildModal> }).modal).toBe(modal)
+    })
+
+    it('实例化：注册划线点击处理器（renderer.setMarkClickHandler）', () => {
+      const config = buildConfig()
+      const modal = buildModal()
+      new DwebArticleSelection(config, buildDeps(), modal)
+      expect(mockRenderer.setMarkClickHandler).toHaveBeenCalledTimes(1)
+      expect(typeof mockRenderer.setMarkClickHandler.mock.calls[0]![0]).toBe('function')
+    })
+  })
+
+  describe('handleExistingMarkClick 点击已有划线', () => {
+    // 取构造时注册进 renderer 的点击回调
+    const getClickHandler = (inst: unknown) => {
+      void inst
+      return mockRenderer.setMarkClickHandler.mock.calls.at(-1)![0] as (ele: HTMLElement, event: PointerEvent) => void
+    }
+
+    const makeMark = (uuid: string, config: SelectionConfig) => {
+      const mark = document.createElement('slax-mark')
+      mark.dataset.uuid = uuid
+      mark.textContent = 'marked'
+      config.monitorDom!.appendChild(mark)
+      return mark
+    }
+
+    it('无 data-uuid / uuid="0"：直接返回，不弹任何 UI', () => {
+      const config = buildConfig()
+      const modal = buildModal()
+      const inst = new DwebArticleSelection(config, buildDeps(), modal)
+      const handler = getClickHandler(inst)
+
+      const plain = document.createElement('span')
+      handler(plain, new MouseEvent('click') as PointerEvent)
+      const zero = makeMark('0', config)
+      handler(zero, new MouseEvent('click') as PointerEvent)
+
+      expect(modal.showMenus).not.toHaveBeenCalled()
+      expect(mockManager.showPanel).not.toHaveBeenCalled()
+    })
+
+    it('纯评论（无 stroke）：updateCurrentMarkItemInfo + showPanel，不弹菜单', () => {
+      const config = buildConfig()
+      const modal = buildModal()
+      const info = { id: 'c1', source: [], comments: [{ markUid: 'x' }], stroke: [] }
+      mockManager.markItemInfos.value = [info]
+      const inst = new DwebArticleSelection(config, buildDeps(), modal)
+      const handler = getClickHandler(inst)
+      const mark = makeMark('c1', config)
+
+      handler(mark, new MouseEvent('click') as PointerEvent)
+      expect(mockManager.updateCurrentMarkItemInfo).toHaveBeenCalledWith(info)
+      expect(mockManager.showPanel).toHaveBeenCalled()
+      expect(modal.showMenus).not.toHaveBeenCalled()
+    })
+
+    it('不可操作（allowAction=false）：即便有 stroke 也退回 showPanel', () => {
+      const config = buildConfig({ allowAction: false })
+      const modal = buildModal()
+      const info = { id: 's0', source: [], comments: [], stroke: [{ mark_uid: 'u', userId: 1 }] }
+      mockManager.markItemInfos.value = [info]
+      const inst = new DwebArticleSelection(config, buildDeps(), modal)
+      const handler = getClickHandler(inst)
+      const mark = makeMark('s0', config)
+
+      handler(mark, new MouseEvent('click') as PointerEvent)
+      expect(mockManager.showPanel).toHaveBeenCalled()
+      expect(modal.showMenus).not.toHaveBeenCalled()
+    })
+
+    it('有 stroke 且可操作：选中分段后弹出 showExistingMarkMenus(isStroked)', async () => {
+      const config = buildConfig()
+      const modal = buildModal()
+      const info = { id: 's1', source: [], comments: [], stroke: [{ mark_uid: 'u', userId: 1 }] }
+      mockManager.markItemInfos.value = [info]
+      const inst = new DwebArticleSelection(config, buildDeps(), modal)
+      const handler = getClickHandler(inst)
+      const mark = makeMark('s1', config)
+
+      handler(mark, new MouseEvent('click') as PointerEvent)
+      await vi.runAllTimersAsync()
+
+      expect(mockManager.updateCurrentMarkItemInfo).toHaveBeenCalledWith(info)
+      expect(modal.showMenus).toHaveBeenCalledTimes(1)
+      expect(modal.showMenus.mock.calls[0]![0]).toMatchObject({ isStroked: true })
+    })
+
+    it('点击命中 img 等子元素：closest 上溯到 slax-mark', () => {
+      const config = buildConfig()
+      const modal = buildModal()
+      const info = { id: 'img1', source: [], comments: [{ markUid: 'x' }], stroke: [] }
+      mockManager.markItemInfos.value = [info]
+      const inst = new DwebArticleSelection(config, buildDeps(), modal)
+      const handler = getClickHandler(inst)
+      const mark = makeMark('img1', config)
+      const img = document.createElement('img')
+      mark.appendChild(img)
+
+      handler(img, new MouseEvent('click') as PointerEvent)
+      expect(mockManager.updateCurrentMarkItemInfo).toHaveBeenCalledWith(info)
     })
   })
 

--- a/apps/slax-reader-dweb/tests/unit/components/Article/Selection/DwebArticleSelection.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/Article/Selection/DwebArticleSelection.spec.ts
@@ -109,8 +109,8 @@ function buildModal() {
   }
 }
 
-function buildDeps() {
-  return {} as never
+function buildDeps(userId: number | null = 1) {
+  return { userProvider: { getUserId: () => userId } } as never
 }
 
 beforeEach(() => {
@@ -227,6 +227,34 @@ describe('DwebArticleSelection', () => {
       expect(mockManager.updateCurrentMarkItemInfo).toHaveBeenCalledWith(info)
       expect(modal.showMenus).toHaveBeenCalledTimes(1)
       expect(modal.showMenus.mock.calls[0]![0]).toMatchObject({ isStroked: true })
+    })
+
+    it('本人已评论该划线：菜单带 hideComment=true', async () => {
+      const config = buildConfig()
+      const modal = buildModal()
+      const info = { id: 'h1', source: [], comments: [{ markUid: 'a', userId: 1, isDeleted: false, children: [] }], stroke: [] }
+      mockManager.markItemInfos.value = [info]
+      const inst = new DwebArticleSelection(config, buildDeps(1), modal)
+      const handler = getClickHandler(inst)
+      const mark = makeMark('h1', config)
+
+      handler(mark, new MouseEvent('click') as PointerEvent)
+      await vi.runAllTimersAsync()
+      expect(modal.showMenus.mock.calls[0]![0]).toMatchObject({ hideComment: true })
+    })
+
+    it('他人评论该划线：本人未评论则 hideComment=false', async () => {
+      const config = buildConfig()
+      const modal = buildModal()
+      const info = { id: 'h2', source: [], comments: [{ markUid: 'a', userId: 2, isDeleted: false, children: [] }], stroke: [] }
+      mockManager.markItemInfos.value = [info]
+      const inst = new DwebArticleSelection(config, buildDeps(1), modal)
+      const handler = getClickHandler(inst)
+      const mark = makeMark('h2', config)
+
+      handler(mark, new MouseEvent('click') as PointerEvent)
+      await vi.runAllTimersAsync()
+      expect(modal.showMenus.mock.calls[0]![0]).toMatchObject({ hideComment: false })
     })
 
     it('点击命中 img 等子元素：closest 上溯到 slax-mark', () => {


### PR DESCRIPTION
## Summary

Clicking an existing highlight on the `/b/[id]` snapshot page now keeps the original behavior (opening the comment side panel) and **additionally** pops up the selection menu for the user's own actionable highlights. In that menu the stroke item is shown as **delete highlight** (删除划线), alongside copy / comment / chat.

Previously a highlight click was routed straight to the comment panel by the built `@slax-reader/selection` package, and the existing-mark menu (`showExistingMarkMenus`, already supporting the `isStroked` → "delete highlight" state) was only reachable by re-selecting matching text.

## Changes

- `DwebArticleSelection` overrides the renderer's mark-click handler and routes clicks through the existing `showExistingMarkMenus` path
- A range is built over the mark's segments so the floating menu can anchor its position
- The menu is deferred (`setTimeout(0)`) to avoid the menu's own `v-click-outside` swallowing the same click, and to let the click-triggered `handleMouseUp` body run first (it bails on the empty selection, so no double menu)
- Pure-comment marks and read-only visitors keep the original panel-only behavior

## Testing

- Added 6 unit tests in `DwebArticleSelection.spec.ts` covering handler registration and all branches (no-uuid, pure-comment, read-only, stroke+actionable, child-img upward resolution)
- `vitest run` on the spec: 20 passed; the 2 remaining failures are pre-existing on `main` (unrelated test-pollution in `mockManager.markItemInfos`)
- `tsc --noEmit` clean for the modified file