### PR TITLE
🐛 show created_at instead of updated_at on detail page

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/Article/BookmarkArticle.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/BookmarkArticle.vue
@@ -100,15 +100,10 @@ const articleStyle = computed(() => {
 })
 
 const dateString = computed(() => {
-  // updated_at 非全部类型都有
-  // 安全访问，缺失则回退
-  const updatedAt = (detail.value as { updated_at?: string }).updated_at
-  const date = updatedAt ?? detail.value.created_at ?? detail.value.published_at ?? ''
-  if (!date || date.length === 0) {
-    return '--'
-  }
+  const date = detail.value.created_at ?? ''
+  if (!date) return ''
 
-  return formatDate(new Date(date), 'YYYY-MM-DD')
+  return t('page.bookmarks_detail.saved_at', { date: formatDate(new Date(date), 'YYYY-MM-DD') })
 })
 
 const articleHTML = computed(() => {

--- a/apps/slax-reader-dweb/layers/core/i18n/locales/en.json
+++ b/apps/slax-reader-dweb/layers/core/i18n/locales/en.json
@@ -489,6 +489,7 @@
       "no_title": "No Title",
       "not_exists": "Bookmark does not exist",
       "processing": "Content is being processed, please wait...",
+      "saved_at": "First saved on { date }",
       "share_bookmark_tips": "Shared by { user } on { date }",
       "trash_bookmark_restore": "Restore to Inbox",
       "trash_bookmark_tips": "Bookmark have been moved to trash { date }. It will automatically be deleted in 7 days.",

--- a/apps/slax-reader-dweb/layers/core/i18n/locales/zh.json
+++ b/apps/slax-reader-dweb/layers/core/i18n/locales/zh.json
@@ -489,6 +489,7 @@
       "no_title": "无标题",
       "not_exists": "书签不存在",
       "processing": "内容正在处理，请稍后 ···",
+      "saved_at": "首次保存于 { date }",
       "share_bookmark_tips": "由 { user } 分享于 { date }",
       "trash_bookmark_restore": "移回 Inbox",
       "trash_bookmark_tips": "书签于 { date } 被放入废纸篓. 7天后将会被删除.",


### PR DESCRIPTION
## Summary
- Detail page time display now uses `created_at` only (dropped the `updated_at`/`published_at` fallback chain).
- New copy: "First saved on { date }" / "首次保存于 { date }", added to both locales.

## Test plan
- [x] `vue-tsc --noEmit` passes
- [ ] Manually verify `/b/[id]` shows the new copy in zh and en