### PR TITLE
🐛  render CJK bold next to full-width punctuation

### DIFF
--- a/commons/utils/src/parse.ts
+++ b/commons/utils/src/parse.ts
@@ -2,6 +2,7 @@ import MdKatex from '@vscode/markdown-it-katex'
 import DOMPurify from 'dompurify'
 import hljs from 'highlight.js'
 import MarkdownIt from 'markdown-it'
+import MdCjkFriendly from 'markdown-it-cjk-friendly'
 import MdLinkAttributes from 'markdown-it-link-attributes'
 
 const highlightBlock = (str: string, lang?: string) => {
@@ -46,7 +47,9 @@ const mdi = new MarkdownIt({
   }
 })
 
-mdi.use(MdLinkAttributes, { attrs: { target: '_blank', rel: 'noopener' } }).use(MdKatex)
+// 修复 CJK 加粗：** 紧邻全角标点
+// 时无法闭合，导致加粗失效
+mdi.use(MdCjkFriendly).use(MdLinkAttributes, { attrs: { target: '_blank', rel: 'noopener' } }).use(MdKatex)
 
 // 转换markdown内容
 export const parseMarkdownText = (text: string) => {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "easy-dom2img": "^1.0.2",
     "highlight.js": "^11.11.1",
     "markdown-it": "^14.1.1",
+    "markdown-it-cjk-friendly": "^2.0.2",
     "markdown-it-link-attributes": "^4.0.1",
     "markmap-common": "^0.18.9",
     "markmap-lib": "^0.18.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
+      markdown-it-cjk-friendly:
+        specifier: ^2.0.2
+        version: 2.0.2(@types/markdown-it@14.1.2)(markdown-it@14.1.1)
       markdown-it-link-attributes:
         specifier: ^4.0.1
         version: 4.0.1
@@ -7476,6 +7479,10 @@ packages:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -8523,6 +8530,16 @@ packages:
 
   many-keys-map@2.0.1:
     resolution: {integrity: sha512-DHnZAD4phTbZ+qnJdjoNEVU1NecYoSdbOOoVmTDH46AuxDkEVh3MxTVpXq10GtcTC6mndN9dkv1rNfpjRcLnOw==}
+
+  markdown-it-cjk-friendly@2.0.2:
+    resolution: {integrity: sha512-KXCl6sd129UqkAiRDb+NcAHrxC9xRa2WsGIsMMvtp2y1YlbeIaNYzArX2zfDoGhOjsyNMfJrGO7xGBss27YQSA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/markdown-it': '*'
+      markdown-it: '*'
+    peerDependenciesMeta:
+      '@types/markdown-it':
+        optional: true
 
   markdown-it-ins@4.0.0:
     resolution: {integrity: sha512-sWbjK2DprrkINE4oYDhHdCijGT+MIDhEupjSHLXe5UXeVr5qmVxs/nTUVtgi0Oh/qtF+QKV0tNWDhQBEPxiMew==}
@@ -19405,6 +19422,8 @@ snapshots:
 
   get-east-asian-width@1.3.0: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -20505,6 +20524,13 @@ snapshots:
   make-error@1.3.6: {}
 
   many-keys-map@2.0.1: {}
+
+  markdown-it-cjk-friendly@2.0.2(@types/markdown-it@14.1.2)(markdown-it@14.1.1):
+    dependencies:
+      get-east-asian-width: 1.6.0
+      markdown-it: 14.1.1
+    optionalDependencies:
+      '@types/markdown-it': 14.1.2
 
   markdown-it-ins@4.0.0: {}
 


### PR DESCRIPTION
CommonMark emphasis flanking rules fail when `**` is adjacent to CJK full-width punctuation (e.g. `"`), leaving the marker unclosed. Add markdown-it-cjk-friendly to fix bold parsing in chat/article.