### PR TITLE
🎨  clamp bookmark titles in list and detail views

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/Article/BookmarkArticle.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/BookmarkArticle.vue
@@ -3,7 +3,7 @@
     <header class="article-header">
       <SnapshotArticleSource v-if="detail.target_url" :url="detail.target_url" />
       <div class="article-divider" />
-      <h1 class="article-title">{{ title }}</h1>
+      <h1 class="article-title" :title="title">{{ title }}</h1>
       <div class="article-info">
         <span v-if="detail.byline" class="article-author">{{ detail.byline }}</span>
         <time class="article-date">{{ dateString }}</time>
@@ -207,6 +207,13 @@ defineExpose({
 }
 
 .article-title {
+  // 最多三行，超出省略号
+  // 完整标题由 title 悬浮展示
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
   font-family: var(--slax-font-serif);
   font-size: var(--slax-fs-display);
   font-weight: 500;
@@ -219,6 +226,11 @@ defineExpose({
   transition: box-shadow 0.15s;
 
   &[contenteditable='true'] {
+    // 编辑态解除截断
+    display: block;
+    -webkit-line-clamp: unset;
+    line-clamp: unset;
+    overflow: visible;
     box-shadow: 0 0 0 1.5px color-mix(in srgb, var(--slax-accent) 50%, transparent);
     padding: 2px 6px;
     margin-left: -6px;

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkCell.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkCell.vue
@@ -8,7 +8,7 @@
       <!-- 标题区：正常态为 button，编辑态为 input -->
       <div class="title-wrap">
         <button v-if="!isEditingTitle" class="article-title" :class="{ stroking: isStroking }" @click.stop="clickTitle">
-          {{ bookmark.alias_title || bookmark.title || bookmark.target_url }}
+          {{ truncateTitle(bookmark.alias_title || bookmark.title, 48) || bookmark.target_url }}
         </button>
         <input
           ref="input"
@@ -520,7 +520,11 @@ const starBookmark = async (isStar: boolean) => {
 
 // 标题按钮
 .article-title {
-  display: inline-block;
+  // 最多两行，超出省略号
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
   max-width: 100%;
   text-align: left;
   background: transparent;
@@ -536,7 +540,6 @@ const starBookmark = async (isStar: boolean) => {
   cursor: pointer;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
   // va:bottom 会裁中文字顶，不用
   transition: color 0.12s;
   position: relative;

--- a/apps/slax-reader-dweb/layers/core/app/utils/string.ts
+++ b/apps/slax-reader-dweb/layers/core/app/utils/string.ts
@@ -1,3 +1,17 @@
+/** 列表标题字数上限 */
+export const TITLE_DISPLAY_MAX = 48
+
+/**
+ * 标题截断到 max 字，超出加省略号。
+ * Array.from 计数，避免截断 emoji。
+ */
+export function truncateTitle(title?: string | null, max = TITLE_DISPLAY_MAX): string {
+  const str = title ?? ''
+  const chars = Array.from(str)
+  if (chars.length <= max) return str
+  return `${chars.slice(0, max).join('')}…`
+}
+
 export function urlBase64ToUint8Array(base64String: string) {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
   const base64 = (base64String + padding).replace(/\-/g, '+').replace(/_/g, '/')


### PR DESCRIPTION
List cell caps titles at 48 chars with a 2-line clamp; the article title uses a 3-line clamp plus a native title-attribute tooltip that reveals the full text on hover.