### PR TITLE
🐛 Fix br span hidden inside code blocks

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/Article/processors/span.processor.ts
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/processors/span.processor.ts
@@ -11,7 +11,7 @@ export class SpanProcessor implements DOMProcessor {
     const spans = Array.from(context.container.querySelectorAll('span')) as HTMLSpanElement[]
 
     spans.forEach(span => {
-      if (span.textContent?.replace(/ /g, '').trim().length === 0 && !span.querySelector('img[src], video[src], picture:has(source[srcset]), svg, canvas')) {
+      if (span.textContent?.replace(/ /g, '').trim().length === 0 && !span.querySelector('img[src], video[src], picture:has(source[srcset]), svg, canvas, br')) {
         span.style.display = 'none'
       }
     })

--- a/apps/slax-reader-dweb/tests/unit/components/Article/processors/span.processor.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/Article/processors/span.processor.spec.ts
@@ -46,6 +46,12 @@ describe('SpanProcessor', () => {
     expect((ctx.container.querySelector('span') as HTMLElement).style.display).not.toBe('none')
   })
 
+  it('空内容 span 含 br（代码块换行占位）：不隐藏', () => {
+    const ctx = buildContext('<span><br></span>')
+    processor.process(ctx)
+    expect((ctx.container.querySelector('span') as HTMLElement).style.display).not.toBe('none')
+  })
+
   it('容器无 span：不抛错', () => {
     const ctx = buildContext('<p>纯文字</p>')
     expect(() => processor.process(ctx)).not.toThrow()


### PR DESCRIPTION
## Summary
- `SpanProcessor` hid any span whose text content is blank and has no visible media child
- WeChat code blocks use `<span><br></span>` per line, which matched this rule and got `display: none`, breaking line breaks in code blocks
- Added `br` to the exclusion selector so spans containing a line break are no longer treated as blank decoration

## Testing
- Added a unit test covering `<span><br></span>` (not hidden)
- `vitest run tests/unit/components/Article/processors/span.processor.spec.ts` — 6/6 passed
- Manually verified on a bookmarked WeChat article with code blocks (dev server)