### PR TITLE
🐛 Fix collect popup crash and overview race

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/Article/processors/image.processor.ts
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/processors/image.processor.ts
@@ -19,6 +19,27 @@ function unwrapImgAnchorsInTweet(container: HTMLElement) {
   })
 }
 
+// 微信公众号文章的图片 style 已由后端保留（含 !important 声明），前端不应再整体覆盖
+const STYLE_PRESERVED_HOSTS = ['mp.weixin.qq.com']
+
+function hasStyleDeclaration(style: string, prop: string): boolean {
+  return new RegExp(`(^|;)\\s*${prop}\\s*:`, 'i').test(style)
+}
+
+// 在已有 style 基础上补齐缺失的 padding/height，而不是整体覆盖
+function ensurePaddingAndHeightStyle(img: HTMLImageElement): void {
+  const currentStyle = img.getAttribute('style') || ''
+  const missing = [!hasStyleDeclaration(currentStyle, 'padding') && 'padding: 0 !important', !hasStyleDeclaration(currentStyle, 'height') && 'height: auto !important'].filter(
+    (declaration): declaration is string => !!declaration
+  )
+
+  if (!missing.length) return
+
+  const trimmedStyle = currentStyle.trim()
+  const separator = trimmedStyle ? (trimmedStyle.endsWith(';') ? ' ' : '; ') : ''
+  img.setAttribute('style', `${trimmedStyle}${separator}${missing.join('; ')};`)
+}
+
 export class ImageProcessor implements DOMProcessor {
   readonly name = 'ImageProcessor'
 
@@ -29,6 +50,7 @@ export class ImageProcessor implements DOMProcessor {
   process(context: WebProcessorContext): void {
     unwrapImgAnchorsInTweet(context.container)
 
+    const preserveStyle = STYLE_PRESERVED_HOSTS.includes(context.url.host)
     const loadingKey = 'slax-image-loading'
     const imgs = Array.from(context.container.querySelectorAll('img')) as HTMLImageElement[]
 
@@ -53,9 +75,10 @@ export class ImageProcessor implements DOMProcessor {
             return
           }
 
-          ;[`padding: 0 !important`, `height: auto !important;`].forEach(style => {
-            img.setAttribute('style', style)
-          })
+          if (!preserveStyle) {
+            img.removeAttribute('style')
+          }
+          ensurePaddingAndHeightStyle(img)
         }
 
         img.onclick = () => {

--- a/apps/slax-reader-dweb/tests/unit/components/Article/processors/image.processor.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/Article/processors/image.processor.spec.ts
@@ -7,12 +7,12 @@ import type { WebProcessorContext } from '~~/layers/core/app/components/Article/
 import { ArticleStyle } from '~~/layers/core/app/components/Article/processors/types'
 import { describe, expect, it, vi } from 'vitest'
 
-function buildContext(html: string, articleStyle = ArticleStyle.Default): WebProcessorContext {
+function buildContext(html: string, articleStyle = ArticleStyle.Default, url = new URL('https://example.com/')): WebProcessorContext {
   const container = document.createElement('div')
   container.innerHTML = html
   return {
     container,
-    url: new URL('https://example.com/'),
+    url,
     articleStyle,
     callbacks: {
       screenLockUpdate: vi.fn(),
@@ -81,6 +81,7 @@ describe('ImageProcessor', () => {
     setNaturalSize(img, 800, 400)
     img.onload?.(new Event('load'))
     expect(img.getAttribute('style')).toContain('height: auto')
+    expect(img.getAttribute('style')).toContain('padding: 0')
 
     expect(img.onclick).not.toBeNull()
     img.onclick!.call(img, new MouseEvent('click') as unknown as PointerEvent)
@@ -93,6 +94,60 @@ describe('ImageProcessor', () => {
     }
     previewArg.dismissHandler()
     expect(ctx.callbacks.screenLockUpdate).toHaveBeenLastCalledWith(false)
+  })
+
+  it('微信文章大图：保留原始 style，且在缺失 padding/height 时基于原样式补齐（非覆盖）', () => {
+    const ctx = buildContext(
+      '<p><span>x</span><img src="https://mmbiz.qpic.cn/i.png" style="vertical-align: middle;max-width: 100%;width: 100%;box-sizing: border-box;"></p>',
+      ArticleStyle.Default,
+      new URL('https://mp.weixin.qq.com/s/xxx')
+    )
+    const img = ctx.container.querySelector('img') as HTMLImageElement
+    processor.process(ctx)
+    setNaturalSize(img, 800, 400)
+    img.onload?.(new Event('load'))
+    // 原始声明保留
+    expect(img.getAttribute('style')).toContain('vertical-align: middle')
+    expect(img.getAttribute('style')).toContain('max-width: 100%')
+    // 原样式缺 padding/height，补齐上去
+    expect(img.getAttribute('style')).toContain('padding: 0 !important')
+    expect(img.getAttribute('style')).toContain('height: auto !important')
+  })
+
+  it('微信文章大图：原样式已带 height，不覆盖其值，只补齐缺失的 padding', () => {
+    const ctx = buildContext('<p><span>x</span><img src="https://mmbiz.qpic.cn/i.png" style="height: 300px;"></p>', ArticleStyle.Default, new URL('https://mp.weixin.qq.com/s/xxx'))
+    const img = ctx.container.querySelector('img') as HTMLImageElement
+    processor.process(ctx)
+    setNaturalSize(img, 800, 400)
+    img.onload?.(new Event('load'))
+    expect(img.getAttribute('style')).toContain('height: 300px')
+    expect(img.getAttribute('style')).not.toContain('height: auto')
+    expect(img.getAttribute('style')).toContain('padding: 0 !important')
+  })
+
+  it('微信文章大图：原样式已带 padding + height，原样保留不追加', () => {
+    const originalStyle = 'padding: 4px; height: 300px;'
+    const ctx = buildContext(
+      `<p><span>x</span><img src="https://mmbiz.qpic.cn/i.png" style="${originalStyle}"></p>`,
+      ArticleStyle.Default,
+      new URL('https://mp.weixin.qq.com/s/xxx')
+    )
+    const img = ctx.container.querySelector('img') as HTMLImageElement
+    processor.process(ctx)
+    setNaturalSize(img, 800, 400)
+    img.onload?.(new Event('load'))
+    expect(img.getAttribute('style')).toBe(originalStyle)
+  })
+
+  it('非微信文章大图：仍覆盖为 padding/height（默认行为不受白名单影响）', () => {
+    const ctx = buildContext('<p><span>x</span><img src="https://x.com/i.png" style="vertical-align: middle;"></p>')
+    const img = ctx.container.querySelector('img') as HTMLImageElement
+    processor.process(ctx)
+    setNaturalSize(img, 800, 400)
+    img.onload?.(new Event('load'))
+    expect(img.getAttribute('style')).toContain('height: auto')
+    expect(img.getAttribute('style')).toContain('padding: 0')
+    expect(img.getAttribute('style')).not.toContain('vertical-align')
   })
 
   it('img onload PhotoSwipeTopic 风格：跳过尺寸调整分支', () => {

--- a/apps/slax-reader-extensions/src/components/AIOverview.vue
+++ b/apps/slax-reader-extensions/src/components/AIOverview.vue
@@ -82,7 +82,11 @@ const tags = ref<BookmarkTag[]>(props.bookmarkBriefInfo.tags)
 const bookmarkId = computed(() => props.bookmarkBriefInfo.bookmark_id)
 const overviewContent = ref(props.bookmarkBriefInfo.overview)
 const keyTakaways = ref<string[]>(props.bookmarkBriefInfo.key_takeaways)
-const haveReconnected = ref(false)
+
+const MAX_RETRY_COUNT = 3
+const RETRY_DELAY_MS = 1500
+const retryCount = ref(0)
+let lastError: Error | null = null
 
 const markdownedOverview = computed(() => {
   if (overviewContent.value.length > 0) {
@@ -235,19 +239,18 @@ const queryOverview = async (
       } catch (error) {
         console.log(error, text)
 
+        lastError = error instanceof Error ? error : new Error(String(error))
         callback(null, true)
-
-        Toast.showToast({
-          text: `${error}`,
-          type: ToastType.Error
-        })
       }
     })
 }
 
-const loadOverview = (options?: { refresh: boolean }) => {
+const loadOverview = (options?: { refresh?: boolean; isRetry?: boolean }) => {
   if (isLoading.value) {
     return
+  }
+  if (!options?.isRetry) {
+    retryCount.value = 0
   }
 
   let step = 0
@@ -292,14 +295,20 @@ const loadOverview = (options?: { refresh: boolean }) => {
     isQueryDone = done
 
     if (isQueryDone) {
-      isLoading.value = false
       isDone.value = true
       clearInterval(timeInterval)
 
-      if (overviewContent.value.length === 0 && !haveReconnected.value) {
-        haveReconnected.value = true
+      if (overviewContent.value.length === 0 && retryCount.value < MAX_RETRY_COUNT) {
+        // 避免闪一下重试按钮
+        // 等退避完再真正重试
+        retryCount.value += 1
         isDone.value = false
-        loadOverview(options)
+        setTimeout(() => loadOverview({ ...options, isRetry: true }), RETRY_DELAY_MS)
+      } else {
+        isLoading.value = false
+        if (overviewContent.value.length === 0 && lastError) {
+          Toast.showToast({ text: `${lastError}`, type: ToastType.Error })
+        }
       }
     } else if (executeStep < step) {
       executeStep = step

--- a/apps/slax-reader-extensions/src/components/Collect.vue
+++ b/apps/slax-reader-extensions/src/components/Collect.vue
@@ -128,11 +128,13 @@ props.browser.runtime.onMessage.addListener(
     switch (action) {
       case MessageTypeAction.ShowCollectPopup: {
         showPopup.value = true
+        break
       }
       case MessageTypeAction.OpenWelcome:
         props.browser.tabs.create({
           url: `${process.env.PUBLIC_BASE_URL}/login?from=extension`
         })
+        break
 
       case MessageTypeAction.QueryHTMLContent:
         sendResponse({


### PR DESCRIPTION
## Summary
- `Collect.vue`'s message listener switch had no `break`, so `ShowCollectPopup` fell through into `OpenWelcome`'s `browser.tabs.create`, which is undefined in a content script and threw on every collect.
- `AIOverview.vue` retried once with zero delay when overview/outline content came back empty right after collecting (server-side content parsing hadn't finished yet), so the retry raced the same window and still failed. Now backs off up to 3 times (1.5s apart) before surfacing the error toast.

## Test plan
- [x] Reload the extension, collect a page, confirm no `Cannot read properties of undefined (reading 'create')` error in the content script console.
- [x] Collect a page and immediately open the Outline/Overview tab on a few different pages; confirm content loads without an error toast once the backend finishes parsing.
- [x] `eslint` clean on both changed files.