### PR TITLE
🐛 Fix cross-paragraph selection matching, anchor highlighting, and empty-mark edge cases

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/DwebArticleSelection.ts
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/DwebArticleSelection.ts
@@ -77,10 +77,13 @@ export class DwebArticleSelection extends BaseArticleSelection {
     return range
   }
 
-  // 选区仍有效时，说明是 click-outside 误判，不应清空
+  // 选区仍有效「且」与弹菜单时不同（如 shift+click 扩展），才说明是 click-outside 误判，不应清空；
+  // 若选区与弹菜单时完全一致（例如点击空白处但原生选区未被真正清除），仍需清空，
+  // 否则 lastMenuRange 不会重置，导致重选同一区域时被 isSameSelectionAsLastMenu 误判为重复而不再弹出菜单
   private hasActiveSelection(): boolean {
     const sel = this.getSelection()
-    return !!sel && sel.rangeCount > 0 && !sel.isCollapsed && sel.toString().trim().length > 0
+    if (!sel || sel.rangeCount === 0 || sel.isCollapsed || sel.toString().trim().length === 0) return false
+    return !this.isSameSelectionAsLastMenu(sel.getRangeAt(0))
   }
 
   // 选区与上次一致即视为重复，跳过

--- a/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/DwebArticleSelection.ts
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/DwebArticleSelection.ts
@@ -77,9 +77,7 @@ export class DwebArticleSelection extends BaseArticleSelection {
     return range
   }
 
-  // 选区仍有效「且」与弹菜单时不同（如 shift+click 扩展），才说明是 click-outside 误判，不应清空；
-  // 若选区与弹菜单时完全一致（例如点击空白处但原生选区未被真正清除），仍需清空，
-  // 否则 lastMenuRange 不会重置，导致重选同一区域时被 isSameSelectionAsLastMenu 误判为重复而不再弹出菜单
+  // 选区仍有效且与上次弹菜单时不同才算误清空，否则 lastMenuRange 不重置会导致重选同一区域不再弹菜单
   private hasActiveSelection(): boolean {
     const sel = this.getSelection()
     if (!sel || sel.rangeCount === 0 || sel.isCollapsed || sel.toString().trim().length === 0) return false

--- a/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotAIPanel.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotAIPanel.vue
@@ -116,9 +116,7 @@ const getScrollParent = (el: HTMLElement): HTMLElement | null => {
   return null
 }
 
-// 固定 360ms 平滑滚动并居中
-// 原生 smooth 太慢会错过高亮
-// 跨段落时传 range 的矩形定位
+// 固定时长平滑滚动至居中（原生 smooth 太慢易错过高亮），跨段落时传 range 矩形定位
 const smoothScrollToCenter = (el: HTMLElement, rect: DOMRect = el.getBoundingClientRect(), duration = 360): Promise<void> => {
   return new Promise(resolve => {
     const scroller = getScrollParent(el)
@@ -159,8 +157,7 @@ const smoothScrollToCenter = (el: HTMLElement, rect: DOMRect = el.getBoundingCli
   })
 }
 
-// 按文字包 <mark> 高亮
-// 不直接高亮整个容器
+// 按文字用 <mark> 包裹高亮，而非整个容器
 const flashRange = (range: Range): HTMLElement[] => {
   const textNodes: Text[] = []
   const root = range.commonAncestorContainer
@@ -719,11 +716,8 @@ watch(
   }
 }
 
-// anchor-flash：锚点点击后正文元素的高亮动画
-// 用 :global 因为 anchor-flash 类加在正文 DOM 上（组件外部）
-// 静态底色兜底：E-ink 禁动画时仍可见
-// 现在也会加到临时插入的 <mark> 上（跨段落锚点按文本片段包裹高亮），
-// 需要显式重置 <mark> 的 UA 默认样式（黑字黄底），保持跟随正文颜色
+// 锚点点击后的高亮动画，:global 因为类加在组件外正文 DOM 上；E-ink 禁动画时靠静态底色兜底
+// 也会加到跨段落临时插入的 <mark> 上，需重置其 UA 默认样式（黑字黄底）以跟随正文颜色
 :global(.anchor-flash) {
   --anchor-flash-bg: color-mix(in srgb, var(--slax-accent) 22%, transparent);
 

--- a/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotAIPanel.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotAIPanel.vue
@@ -118,7 +118,8 @@ const getScrollParent = (el: HTMLElement): HTMLElement | null => {
 
 // 固定 360ms 平滑滚动并居中
 // 原生 smooth 太慢会错过高亮
-const smoothScrollToCenter = (el: HTMLElement, duration = 360): Promise<void> => {
+// 跨段落时传 range 的矩形定位
+const smoothScrollToCenter = (el: HTMLElement, rect: DOMRect = el.getBoundingClientRect(), duration = 360): Promise<void> => {
   return new Promise(resolve => {
     const scroller = getScrollParent(el)
     const isWindow = !scroller
@@ -126,7 +127,7 @@ const smoothScrollToCenter = (el: HTMLElement, duration = 360): Promise<void> =>
     const scrollHeight = isWindow ? document.documentElement.scrollHeight : scroller!.scrollHeight
     const startTop = isWindow ? window.scrollY : scroller!.scrollTop
 
-    const elRect = el.getBoundingClientRect()
+    const elRect = rect
     const baseTop = isWindow ? elRect.top + window.scrollY : startTop + (elRect.top - scroller!.getBoundingClientRect().top)
     const maxTop = Math.max(0, scrollHeight - viewportH)
     const targetTop = Math.max(0, Math.min(baseTop - viewportH / 2 + elRect.height / 2, maxTop))
@@ -158,13 +159,63 @@ const smoothScrollToCenter = (el: HTMLElement, duration = 360): Promise<void> =>
   })
 }
 
+// 按文字包 <mark> 高亮
+// 不直接高亮整个容器
+const flashRange = (range: Range): HTMLElement[] => {
+  const textNodes: Text[] = []
+  const root = range.commonAncestorContainer
+  if (root.nodeType === Node.TEXT_NODE) {
+    // 未跨元素时本身就是文本节点
+    textNodes.push(root as Text)
+  } else {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode: node => (range.intersectsNode(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT)
+    })
+    let node = walker.nextNode()
+    while (node) {
+      textNodes.push(node as Text)
+      node = walker.nextNode()
+    }
+  }
+
+  const marks: HTMLElement[] = []
+  textNodes.forEach(textNode => {
+    const subRange = document.createRange()
+    subRange.selectNodeContents(textNode)
+    if (textNode === range.startContainer) subRange.setStart(textNode, range.startOffset)
+    if (textNode === range.endContainer) subRange.setEnd(textNode, range.endOffset)
+    if (subRange.collapsed) return
+
+    const mark = document.createElement('mark')
+    mark.className = 'anchor-flash'
+    try {
+      subRange.surroundContents(mark)
+      marks.push(mark)
+    } catch {
+      // 极少数情况会抛错，跳过
+    }
+  })
+
+  return marks
+}
+
+const unflash = (marks: HTMLElement[]) => {
+  marks.forEach(mark => {
+    const parent = mark.parentNode
+    if (!parent) return
+    while (mark.firstChild) parent.insertBefore(mark.firstChild, mark)
+    parent.removeChild(mark)
+    parent.normalize()
+  })
+}
+
 const handleAnchorClick = async (link: string) => {
   const refText = anchorRefs[link]
   if (!refText) return
   // 在正文区查找目标文本
   const contentEl = document.querySelector('.bookmark-detail .detail') || document.body
   const result = findMatchingElement(refText, contentEl)
-  if (result?.element) {
+  if (result?.element && result.range) {
     const el = result.element as HTMLElement
     // 小屏先收起侧栏避免遮挡
     if (isH5.value) {
@@ -173,11 +224,9 @@ const handleAnchorClick = async (link: string) => {
       await nextTick()
     }
     // 先滚到位再高亮，确保可见
-    await smoothScrollToCenter(el)
-    el.classList.remove('anchor-flash')
-    void el.offsetWidth // 强制 reflow 重触发动画
-    el.classList.add('anchor-flash')
-    setTimeout(() => el.classList.remove('anchor-flash'), 3000)
+    await smoothScrollToCenter(el, result.range.getBoundingClientRect())
+    const marks = flashRange(result.range)
+    setTimeout(() => unflash(marks), 3000)
   }
 }
 
@@ -673,10 +722,13 @@ watch(
 // anchor-flash：锚点点击后正文元素的高亮动画
 // 用 :global 因为 anchor-flash 类加在正文 DOM 上（组件外部）
 // 静态底色兜底：E-ink 禁动画时仍可见
+// 现在也会加到临时插入的 <mark> 上（跨段落锚点按文本片段包裹高亮），
+// 需要显式重置 <mark> 的 UA 默认样式（黑字黄底），保持跟随正文颜色
 :global(.anchor-flash) {
   --anchor-flash-bg: color-mix(in srgb, var(--slax-accent) 22%, transparent);
 
   background-color: var(--anchor-flash-bg);
+  color: inherit;
   border-radius: 4px;
   animation: anchor-flash 3s ease-out forwards;
 }

--- a/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotCommentList.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotCommentList.vue
@@ -101,15 +101,17 @@ const getStrokeUser = (info: MarkItemInfo) => {
 }
 
 const getQuoteText = (info: MarkItemInfo): string => {
-  // 优先用 approx.exact（服务端存储的精确文本，不依赖 DOM）
-  if (info.approx?.exact) return info.approx.exact
-
   if (!info.source.length) return ''
-  const textItems = info.source.filter(s => s.type === 'text')
-  if (!textItems.length) return ''
+  const hasImage = info.source.some(s => s.type === 'image')
+
+  // 纯文本划线优先用 approx.exact（服务端存储的精确文本，不依赖 DOM）
+  if (!hasImage && info.approx?.exact) return info.approx.exact
+
+  // 含图片时按原始顺序逐项拼接，图片以 emoji 占位（对齐 Chat 侧的引用展示）
   try {
-    return textItems
+    return info.source
       .map(item => {
+        if (item.type === 'image') return '🖼️'
         const el = document.querySelector(item.path)
         if (!el) return ''
         const text = el.textContent || ''
@@ -117,7 +119,7 @@ const getQuoteText = (info: MarkItemInfo): string => {
       })
       .join('')
   } catch {
-    return ''
+    return hasImage ? '🖼️' : ''
   }
 }
 

--- a/apps/slax-reader-dweb/tests/unit/utils/search.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/utils/search.spec.ts
@@ -2,8 +2,7 @@ import { findBestMatch } from '@commons/utils/search'
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-// happy-dom 无真实布局，
-// 打桩 offset 值模拟可见
+// happy-dom 无真实布局，打桩 offset 值模拟可见
 beforeAll(() => {
   Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 1 })
   Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => 1 })

--- a/apps/slax-reader-dweb/tests/unit/utils/search.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/utils/search.spec.ts
@@ -1,0 +1,118 @@
+import { findBestMatch } from '@commons/utils/search'
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+// happy-dom 无真实布局，
+// 打桩 offset 值模拟可见
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 1 })
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => 1 })
+})
+
+afterAll(() => {
+  Reflect.deleteProperty(HTMLElement.prototype, 'offsetHeight')
+  Reflect.deleteProperty(HTMLElement.prototype, 'offsetWidth')
+})
+
+describe('findBestMatch', () => {
+  const anchor = 'You need pressure. Tactical stress.'
+
+  it('matches text that is contiguous within a single text node with 0 errors', () => {
+    const container = document.createElement('div')
+    container.innerHTML = `<p>${anchor}</p>`
+
+    const result = findBestMatch(anchor, container)
+    expect(result?.match.errors).toBe(0)
+  })
+
+  it('matches text split across a <br> line break with 0 errors', () => {
+    const container = document.createElement('div')
+    container.innerHTML = '<p>You need pressure.<br>Tactical stress.</p>'
+
+    const result = findBestMatch(anchor, container)
+    expect(result?.match.errors).toBe(0)
+  })
+
+  it('matches text split across adjacent block elements with 0 errors', () => {
+    const container = document.createElement('div')
+    container.innerHTML = '<p>You need pressure.</p><p>Tactical stress.</p>'
+
+    const result = findBestMatch(anchor, container)
+    expect(result?.match.errors).toBe(0)
+  })
+
+  it('does not match text embedded in a <script> payload (e.g. Nuxt hydration data), preferring the visible DOM occurrence', () => {
+    const container = document.createElement('div')
+    // 模拟水合 JSON 里的原文
+    container.innerHTML = `
+      <script type="application/json">${JSON.stringify({ outline: anchor })}</script>
+      <article><p>You need pressure.<br>Tactical stress.</p></article>
+    `
+
+    const result = findBestMatch(anchor, container)
+    expect(result?.element.tagName).not.toBe('SCRIPT')
+    expect(result?.element.closest('article')).not.toBeNull()
+  })
+
+  it('produces a match range whose raw offsets are valid within element.textContent', () => {
+    const container = document.createElement('div')
+    container.innerHTML = '<p>You need pressure.</p><p>Tactical stress.</p>'
+
+    const result = findBestMatch(anchor, container)
+    expect(result).not.toBeNull()
+    const slice = result!.element.textContent!.slice(result!.match.start, result!.match.end)
+    // DOM 里没空格，少 1 个字符
+    expect(slice).toBe('You need pressure.Tactical stress.')
+  })
+
+  it('keeps raw offsets aligned when an emoji (non-BMP, 2 UTF-16 code units) precedes the match in the same element', () => {
+    const container = document.createElement('div')
+    // emoji 与命中文本同元素
+    container.innerHTML = `<p>😀 ${anchor}</p>`
+
+    const result = findBestMatch(anchor, container)
+    expect(result).not.toBeNull()
+    expect(result!.match.errors).toBe(0)
+    const slice = result!.element.textContent!.slice(result!.match.start, result!.match.end)
+    expect(slice).toBe(anchor)
+  })
+
+  it('does not produce an out-of-bounds (undefined) end offset when an emoji precedes an exact match', () => {
+    // exact 路径最易暴露码点计数错位
+    const container = document.createElement('div')
+    container.innerHTML = '<p>😀 abc</p>'
+
+    const result = findBestMatch('abc', container, false)
+    expect(result).not.toBeNull()
+    expect(result!.match.start).not.toBeUndefined()
+    expect(result!.match.end).not.toBeUndefined()
+    expect(result!.element.textContent!.slice(result!.match.start, result!.match.end)).toBe('abc')
+  })
+
+  it('produces a valid (non-undefined) end offset when the match exactly fills a cached leaf element', () => {
+    // 命中区间刚好到元素内容末尾
+    const container = document.createElement('div')
+    container.innerHTML = '<ul><li><strong>Systems thinking</strong> - more text after it.</li></ul>'
+
+    const result = findBestMatch('Systems thinking', container)
+    expect(result).not.toBeNull()
+    expect(result!.match.end).not.toBeUndefined()
+    expect(result!.element.textContent!.slice(result!.match.start, result!.match.end)).toBe('Systems thinking')
+  })
+
+  it('produces the same result whether a subtree is visited directly or reached through a wrapping ancestor first (subtree-text cache)', () => {
+    const container = document.createElement('div')
+    container.innerHTML = `
+      <section>
+        <div><p>unrelated filler text here</p></div>
+        <article><p>You need pressure.</p><p>Tactical stress.</p></article>
+      </section>
+    `
+
+    const result = findBestMatch(anchor, container)
+    expect(result).not.toBeNull()
+    expect(result!.match.errors).toBe(0)
+    const slice = result!.element.textContent!.slice(result!.match.start, result!.match.end)
+    expect(slice).toBe('You need pressure.Tactical stress.')
+  })
+})

--- a/commons/selection/src/core/MarkManager.ts
+++ b/commons/selection/src/core/MarkManager.ts
@@ -1,3 +1,4 @@
+import { trimRangeEnd } from '@commons/utils/dom'
 import { HighlightRange, type HighlightRangeInfo } from '@commons/utils/range'
 import { getRangeTextWithNewlines } from '@commons/utils/string'
 import { RESTMethodPath } from '@commons/types/const'
@@ -559,8 +560,10 @@ export class MarkManager extends Base {
    * @returns 元素信息
    */
   getElementInfo(range: Range): { list: SelectTextInfo[]; approx: HighlightRangeInfo | undefined } {
-    const list = this.getElementsList(range)
-    const approx = this.getApproxText(range)
+    // 避免影响原生选区高亮
+    const trimmedRange = trimRangeEnd(range.cloneRange(), this.document)
+    const list = this.getElementsList(trimmedRange)
+    const approx = this.getApproxText(trimmedRange)
 
     return {
       list,

--- a/commons/selection/src/core/MarkRenderer.ts
+++ b/commons/selection/src/core/MarkRenderer.ts
@@ -101,8 +101,13 @@ export class MarkRenderer extends Base {
     if (!this.config.commentTailIndicator) return
     marks.forEach(m => m.classList.remove('slax-mk-comment-tail'))
     if (!isComment || marks.length === 0) return
+
+    // 跳过空段，防止误标尾段
+    const hasContent = (m: HTMLElement) => (m.textContent?.trim().length ?? 0) > 0 || Array.from(m.children).some(el => el.tagName === 'IMG')
+    const tail = [...marks].reverse().find(hasContent)
+    if (!tail) return
+
     // 末段是图片则跳过（已有 ···）
-    const tail = marks[marks.length - 1]
     if (Array.from(tail.children).some(el => el.tagName === 'IMG')) return
     tail.classList.add('slax-mk-comment-tail')
   }
@@ -128,20 +133,25 @@ export class MarkRenderer extends Base {
   addMarksInRange(range: Range, baseInfo: DrawMarkBaseInfo) {
     const markHandler = this.addMark.bind(this)
 
+    // 避免生成零宽空 mark
+    const hasContent = (node: Node, start: number, end: number) => end > start && (node.textContent || '').slice(start, end).trim().length > 0
+
     if (range.startContainer === range.endContainer) {
-      markHandler({
-        ...baseInfo,
-        node: range.startContainer,
-        start: range.startOffset,
-        end: range.endOffset
-      })
+      if (hasContent(range.startContainer, range.startOffset, range.endOffset)) {
+        markHandler({
+          ...baseInfo,
+          node: range.startContainer,
+          start: range.startOffset,
+          end: range.endOffset
+        })
+      }
       return
     }
 
     const nodes = getTextNodesInRange(range, this.document)
 
     if (nodes.length > 0) {
-      if (nodes[0] === range.startContainer) {
+      if (nodes[0] === range.startContainer && hasContent(nodes[0], range.startOffset, (nodes[0].textContent || '').length)) {
         markHandler({
           ...baseInfo,
           node: nodes[0],
@@ -159,7 +169,7 @@ export class MarkRenderer extends Base {
         })
       }
 
-      if (nodes.length > 1 && nodes[nodes.length - 1] === range.endContainer) {
+      if (nodes.length > 1 && nodes[nodes.length - 1] === range.endContainer && hasContent(nodes[nodes.length - 1], 0, range.endOffset)) {
         markHandler({
           ...baseInfo,
           node: nodes[nodes.length - 1],

--- a/commons/utils/src/dom.ts
+++ b/commons/utils/src/dom.ts
@@ -203,6 +203,38 @@ export const createStyleWithSearchRules = async (searchRules: string[]) => {
   return styleElement
 }
 
+// 避免选区带上尾部换行
+export const trimRangeEnd = (range: Range, doc: Document = document): Range => {
+  if (range.collapsed) return range
+
+  const trimTextOffset = (text: string, offset: number): number => {
+    while (offset > 0 && /\s/.test(text[offset - 1])) offset--
+    return offset
+  }
+
+  if (range.endContainer.nodeType === Node.TEXT_NODE) {
+    const endNode = range.endContainer as Text
+    const trimmedOffset = trimTextOffset(endNode.data, range.endOffset)
+
+    if (trimmedOffset > 0 || endNode === range.startContainer) {
+      range.setEnd(endNode, trimmedOffset)
+      return range
+    }
+
+    // 退到前一非空白节点
+    // 同样需 trim 尾部
+    const textNodes = getTextNodesInRange(range, doc)
+    for (let i = textNodes.length - 1; i >= 0; i--) {
+      if (textNodes[i] === endNode) continue
+      const prevNode = textNodes[i] as Text
+      range.setEnd(prevNode, trimTextOffset(prevNode.data, prevNode.data.length))
+      return range
+    }
+  }
+
+  return range
+}
+
 export const getTextNodesInRange = (range: Range, doc: Document = document): Node[] => {
   const nodes: Node[] = []
 

--- a/commons/utils/src/dom.ts
+++ b/commons/utils/src/dom.ts
@@ -221,8 +221,7 @@ export const trimRangeEnd = (range: Range, doc: Document = document): Range => {
       return range
     }
 
-    // 退到前一非空白节点
-    // 同样需 trim 尾部
+    // 退到前一个非空白节点，同样需 trim 尾部
     const textNodes = getTextNodesInRange(range, doc)
     for (let i = textNodes.length - 1; i >= 0; i--) {
       if (textNodes[i] === endNode) continue

--- a/commons/utils/src/search.ts
+++ b/commons/utils/src/search.ts
@@ -60,14 +60,10 @@ const LINE_BREAK_TAGS = new Set([
   'ADDRESS'
 ])
 
-// trueLength：内容真实长度
-// 末尾越界时用它兜底
+// trueLength 为内容真实长度，越界回退用它兜底
 type SearchableText = { content: string; rawOffsets: number[]; trueLength: number }
 
-/**
- * 构造带换行分隔符的可搜索文本
- * 按元素缓存，避免重复遍历
- */
+// 构造带换行分隔符的可搜索文本，按元素缓存避免重复遍历
 function getSearchableText(root: Element, cache: WeakMap<Element, SearchableText>): SearchableText {
   const cached = cache.get(root)
   if (cached) {

--- a/commons/utils/src/search.ts
+++ b/commons/utils/src/search.ts
@@ -16,6 +16,120 @@ function normalizeWithRanges(raw: string) {
   return { text, ranges }
 }
 
+// 跳过脚本/样式，防止误配水合数据
+const NON_VISIBLE_TAGS = new Set(['SCRIPT', 'STYLE', 'TEMPLATE', 'NOSCRIPT', 'TITLE'])
+
+// 块级标签换行处补一个空格
+const LINE_BREAK_TAGS = new Set([
+  'P',
+  'DIV',
+  'LI',
+  'UL',
+  'OL',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+  'BLOCKQUOTE',
+  'TABLE',
+  'THEAD',
+  'TBODY',
+  'TFOOT',
+  'TR',
+  'TD',
+  'TH',
+  'SECTION',
+  'ARTICLE',
+  'HEADER',
+  'FOOTER',
+  'NAV',
+  'ASIDE',
+  'MAIN',
+  'PRE',
+  'HR',
+  'DL',
+  'DT',
+  'DD',
+  'FIGURE',
+  'FIGCAPTION',
+  'DETAILS',
+  'SUMMARY',
+  'FORM',
+  'ADDRESS'
+])
+
+// trueLength：内容真实长度
+// 末尾越界时用它兜底
+type SearchableText = { content: string; rawOffsets: number[]; trueLength: number }
+
+/**
+ * 构造带换行分隔符的可搜索文本
+ * 按元素缓存，避免重复遍历
+ */
+function getSearchableText(root: Element, cache: WeakMap<Element, SearchableText>): SearchableText {
+  const cached = cache.get(root)
+  if (cached) {
+    return cached
+  }
+
+  let content = ''
+  const rawOffsets: number[] = []
+  let trueOffset = 0
+
+  function appendSeparator() {
+    if (content.length > 0 && !/\s$/.test(content)) {
+      content += ' '
+      rawOffsets.push(trueOffset)
+    }
+  }
+
+  function walk(node: ChildNode) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.nodeValue || ''
+      for (let i = 0; i < text.length; i++) {
+        content += text[i]
+        rawOffsets.push(trueOffset)
+        trueOffset++
+      }
+      return
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return
+    }
+
+    const element = node as Element
+    if (NON_VISIBLE_TAGS.has(element.tagName)) {
+      trueOffset += (element.textContent || '').length
+      return
+    }
+
+    if (element.tagName === 'BR') {
+      appendSeparator()
+      return
+    }
+
+    // 递归查缓存，未命中才遍历
+    const childResult = getSearchableText(element, cache)
+    const base = trueOffset
+    content += childResult.content
+    childResult.rawOffsets.forEach(offset => rawOffsets.push(base + offset))
+    trueOffset += childResult.trueLength
+
+    if (LINE_BREAK_TAGS.has(element.tagName)) {
+      appendSeparator()
+    }
+  }
+
+  root.childNodes.forEach(walk)
+
+  const result: SearchableText = { content, rawOffsets, trueLength: trueOffset }
+  cache.set(root, result)
+  return result
+}
+
 // 查找最合适的匹配元素
 export function findBestMatch(text: string, dom?: Element, fuzzy: boolean = true): { element: HTMLElement; match: { start: number; end: number; errors: number } } | null {
   const normalizedText = text.trim().replace(/\s+/g, ' ')
@@ -30,6 +144,9 @@ export function findBestMatch(text: string, dom?: Element, fuzzy: boolean = true
     } | null
   } = { candidate: null }
 
+  // 缓存子树文本，避免重复遍历
+  const searchableTextCache = new WeakMap<Element, SearchableText>()
+
   function traverse(node: Node) {
     if (node.nodeType === Node.ELEMENT_NODE) {
       const element = node as HTMLElement
@@ -39,8 +156,10 @@ export function findBestMatch(text: string, dom?: Element, fuzzy: boolean = true
         return
       }
 
-      const content = element.textContent
-      const { text, ranges } = normalizeWithRanges(content || '')
+      const { content, rawOffsets, trueLength } = getSearchableText(element, searchableTextCache)
+      const { text, ranges } = normalizeWithRanges(content)
+      // 换算回真实下标，越界用 trueLength 兜底
+      const toRawOffset = (index: number) => (index < rawOffsets.length ? rawOffsets[index]! : trueLength)
 
       if (content && content.length >= normalizedText.length - maxErrors) {
         const matches = search(text, normalizedText, maxErrors)
@@ -53,8 +172,8 @@ export function findBestMatch(text: string, dom?: Element, fuzzy: boolean = true
             bestMatchInElement.errors < result.candidate.errors ||
             (bestMatchInElement.errors === result.candidate.errors && content.length <= result.candidate.length)
           ) {
-            const rawStart = ranges[bestMatchInElement.start]!.start
-            const rawEnd = ranges[bestMatchInElement.end - 1]!.end
+            const rawStart = toRawOffset(ranges[bestMatchInElement.start]!.start)
+            const rawEnd = toRawOffset(ranges[bestMatchInElement.end - 1]!.end)
 
             result.candidate = {
               element,
@@ -77,8 +196,8 @@ export function findBestMatch(text: string, dom?: Element, fuzzy: boolean = true
               errors: 0,
               length: content.length,
               match: {
-                start: exactMatch.index,
-                end: exactMatch.index + exactMatch[0].length,
+                start: toRawOffset(exactMatch.index),
+                end: toRawOffset(exactMatch.index + exactMatch[0].length),
                 errors: 0
               }
             }


### PR DESCRIPTION
## Summary
- `findBestMatch` (search.ts) compared raw `textContent` against a normalized search string with no separators at block boundaries, so text spanning adjacent paragraphs/list items matched incorrectly or not at all. `getSearchableText` now builds a cached, separator-aware text representation per element and maps normalized offsets back to raw DOM offsets.
- `hasActiveSelection` (DwebArticleSelection.ts) treated any still-active selection as a click-outside false positive, so re-selecting the exact same range that had already opened the menu never reopened it (`lastMenuRange` was never reset). It now only short-circuits when the selection differs from the last menu range.
- Anchor click highlighting in `SnapshotAIPanel.vue` only flashed the whole matched element, which broke once a match could span multiple elements; it now wraps the actual matched `Range` in `<mark>` segments via `flashRange`/`unflash` and scrolls using the range's own rect.
- `MarkManager`/`MarkRenderer` could record or render trailing-newline or zero-width empty marks, and comment-tail indicators could land on an empty trailing segment instead of the last real one.
- `SnapshotCommentList`'s `getQuoteText` now includes image sources as an emoji placeholder instead of dropping them when a quote mixes text and images.

## Test plan
- [x] Added unit coverage for the new search offset mapping in `search.spec.ts`
- [ ] Manually verify cross-paragraph text selection creates a highlight/comment correctly
- [ ] Manually verify anchor click from AI panel scrolls to and highlights a cross-paragraph quote
- [ ] Manually verify re-selecting the same text after closing the selection menu reopens it