### PR TITLE
✨ improve inbox empty states and tooltip coverage

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkListContent.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkListContent.vue
@@ -171,6 +171,10 @@ const emit = defineEmits<{
     margin-left: 0;
     color: var(--slax-text-light);
     font-weight: 300;
+
+    &:hover {
+      color: var(--slax-accent);
+    }
   }
 
   // 星标：缩小 icon，绝对定位并与标题垂直居中
@@ -240,6 +244,10 @@ const emit = defineEmits<{
       color: var(--slax-text-light);
       padding: 0 0 0 8px;
       max-width: 54vw;
+
+      &:hover {
+        color: var(--slax-accent);
+      }
     }
 
     .article-actions {

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksEmptyView.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksEmptyView.vue
@@ -34,6 +34,8 @@ const emit = defineEmits<{ action: [] }>()
   justify-content: center;
   text-align: center;
   padding: 96px 24px 48px;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .empty-view-icon {

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/SearchHeader.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/SearchHeader.vue
@@ -29,9 +29,19 @@
     <ListEndHint v-if="!isSearching && searchResults.length > 0" class="search-end" :text="$t('page.bookmarks_index.no_more')" />
 
     <!-- 空态 -->
-    <div class="search-empty" v-if="!isSearching && searchResults.length === 0 && defaultSearchText">
-      {{ $t('component.search_header.empty') }}
-    </div>
+    <BookmarksEmptyView
+      v-if="!isSearching && searchResults.length === 0 && defaultSearchText"
+      class="search-empty"
+      :title="$t('component.search_header.empty')"
+      :desc="$t('component.search_header.empty_desc')"
+    >
+      <template #icon>
+        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <circle cx="11" cy="11" r="7" />
+          <path d="m20 20-4-4" />
+        </svg>
+      </template>
+    </BookmarksEmptyView>
 
     <!-- 加载中 -->
     <div class="search-loading" v-if="isSearching">
@@ -41,6 +51,7 @@
 </template>
 
 <script lang="ts" setup>
+import BookmarksEmptyView from '#layers/core/app/components/BookmarkList/BookmarksEmptyView.vue'
 import ListEndHint from '#layers/core/app/components/ListEndHint.vue'
 
 import { RESTMethodPath } from '@commons/types/const'
@@ -229,13 +240,6 @@ const search = async (text: string) => {
 
 .search-end {
   margin-top: 32px;
-}
-
-.search-empty {
-  padding: 48px 0;
-  text-align: center;
-  color: var(--slax-text-light);
-  font-size: 14px;
 }
 
 .search-loading {

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/TagsHeader.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/TagsHeader.vue
@@ -51,6 +51,20 @@
           </div>
         </div>
       </div>
+
+      <BookmarksEmptyView
+        v-if="!isTagLoading && tags.length === 0"
+        class="tags-empty"
+        :title="$t('page.bookmarks_index.empty_topics_title')"
+        :desc="$t('page.bookmarks_index.empty_topics_desc')"
+      >
+        <template #icon>
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M20.59 13.41 11 3.83V3H4v7h.83l9.58 9.59a2 2 0 0 0 2.82 0l3.36-3.36a2 2 0 0 0 0-2.82Z" />
+            <circle cx="7.5" cy="6.5" r="1" />
+          </svg>
+        </template>
+      </BookmarksEmptyView>
     </template>
 
     <!-- 已选标签：显示返回 + 标签名 -->
@@ -66,6 +80,8 @@
 </template>
 
 <script lang="ts" setup>
+import BookmarksEmptyView from '#layers/core/app/components/BookmarkList/BookmarksEmptyView.vue'
+
 import { RESTMethodPath } from '@commons/types/const'
 import type { BookmarkTag } from '@commons/types/interface'
 import { vOnKeyStroke } from '@vueuse/components'

--- a/apps/slax-reader-extensions/src/components/PanelView.vue
+++ b/apps/slax-reader-extensions/src/components/PanelView.vue
@@ -17,12 +17,12 @@
               <span class="name">Slax Reader</span>
               <span class="version">{{ VERSION }}</span>
             </div>
-            <div class="header-toggle">
-              <span>{{ isAutoToggle ? $t('component.panel.auto_toggle.on') : $t('component.panel.auto_toggle.off') }}</span>
-              <TextTips :tips="isAutoToggle ? $t('component.panel.auto_toggle.enabled_tips') : $t('component.panel.auto_toggle.disabled_tips', [shortcutString])">
+            <TextTips :tips="isAutoToggle ? $t('component.panel.auto_toggle.enabled_tips') : $t('component.panel.auto_toggle.disabled_tips', [shortcutString])">
+              <div class="header-toggle">
+                <span>{{ isAutoToggle ? $t('component.panel.auto_toggle.on') : $t('component.panel.auto_toggle.off') }}</span>
                 <button :class="{ enabled: isAutoToggle }" @click="switchClick"></button>
-              </TextTips>
-            </div>
+              </div>
+            </TextTips>
           </div>
           <div class="sidebar-content">
             <slot name="content" />


### PR DESCRIPTION
## Summary
- reuse the unified empty-state component for search with no results and empty tags
- prevent empty-state copy and icons from being text-selected
- add hover accent feedback for article sources in text list mode
- expand header-toggle tooltip coverage to include its label

## Validation
- related ESLint checks passed
- dweb vue-tsc passed

This PR is consumed by the fork frontend PR.