### PR TITLE
✨ refine inbox links and extension menu

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/Article/processors/tweet.processor.ts
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/processors/tweet.processor.ts
@@ -1,4 +1,4 @@
-import { TweetFooterInfoElement, TweetUserInfoElement } from '../CEComponents'
+import { TweetFooterInfoElement } from '../CEComponents'
 import type { DOMProcessor, WebProcessorContext } from './types'
 import { ArticleStyle } from './types'
 
@@ -12,20 +12,7 @@ export class TweetProcessor implements DOMProcessor {
   process(context: WebProcessorContext): void {
     const tweetHeader = context.container.querySelector('tweet-header')
     if (tweetHeader && tweetHeader instanceof HTMLElement) {
-      const tweetHeaderElement = new TweetUserInfoElement({
-        href: tweetHeader.dataset['href'],
-        avatar: tweetHeader.dataset['avatar'],
-        name: tweetHeader.dataset['name'],
-        description: tweetHeader.dataset['description'],
-        screenName: tweetHeader.dataset['screenName'],
-        location: tweetHeader.dataset['location'],
-        website: tweetHeader.dataset['website'],
-        createdAt: tweetHeader.dataset['createdAt'],
-        followers: parseInt(tweetHeader.dataset['followers'] || '0'),
-        followings: parseInt(tweetHeader.dataset['followings'] || '0')
-      })
-
-      tweetHeader.parentElement?.replaceChild(tweetHeaderElement, tweetHeader)
+      tweetHeader.remove()
     }
 
     const tweetFooter = context.container.querySelector('tweet-footer')

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkCell.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkCell.vue
@@ -1,15 +1,24 @@
 <template>
   <!-- 卡片条目：点击整卡跳快照 -->
-  <div class="article-card" :class="{ deleting: isDeleting, editing: isEditingTitle }" @click="clickCard">
+  <div class="article-card" :class="{ deleting: isDeleting, editing: isEditingTitle }">
+    <a class="article-card-link" :href="articleHref" target="_blank" rel="noopener noreferrer" :aria-label="bookmark.alias_title || bookmark.title" @click.stop.prevent="clickCard"></a>
     <!-- 序号 -->
     <span class="article-num">{{ index !== undefined ? index + 1 : '' }}</span>
 
     <div class="article-body">
-      <!-- 标题区：正常态为 button，编辑态为 input -->
+      <!-- 标题区 -->
       <div class="title-wrap">
-        <button v-if="!isEditingTitle" class="article-title" :class="{ stroking: isStroking }" @click.stop="clickTitle">
+        <a
+          v-if="!isEditingTitle"
+          class="article-title"
+          :class="{ stroking: isStroking }"
+          :href="articleHref"
+          target="_blank"
+          rel="noopener noreferrer"
+          @click.stop.prevent="clickTitle"
+        >
           {{ truncateTitle(bookmark.alias_title || bookmark.title, 48) || bookmark.target_url }}
-        </button>
+        </a>
         <input
           ref="input"
           type="text"
@@ -32,7 +41,7 @@
       <!-- meta 行：日期 + 来源 + hover 操作区 -->
       <div class="article-meta">
         <span class="article-date">{{ dateString }}</span>
-        <span class="article-source" @click.stop="clickHref">{{ getSiteName() }}</span>
+        <a class="article-source" :href="articleHref" target="_blank" rel="noopener noreferrer" @click.stop.prevent="clickHref">{{ getSiteName() }}</a>
 
         <!-- hover 操作区 -->
         <div class="article-actions">
@@ -213,6 +222,18 @@ const getSiteName = () => {
   const siteName = bookmark.value.site_name || bookmark.value.host_url
   return bookmark.value.type === 'shortcut' ? t('component.bookmark_cell.shortcut') + ' ' + siteName : siteName
 }
+
+const articleHref = computed(() => {
+  if (props.isSubscribe) {
+    const uuid = bookmark.value.bookmark_user_uuid
+    if (uuid) return `/b/${uuid}`
+    if (props.collectionCode) return `/c/${props.collectionCode}/${bookmark.value.id}`
+  }
+
+  return bookmark.value.status === 'success' && bookmark.value.type !== 'shortcut'
+    ? useSlaxRoutes().snapshotRoute(bookmark.value) || urlHttpString(bookmark.value.target_url)
+    : urlHttpString(bookmark.value.target_url)
+})
 
 const archiveBookmark = async (archive: boolean) => {
   if (isRequesting.value) {
@@ -472,6 +493,8 @@ const starBookmark = async (isStar: boolean) => {
   max-height: 200px;
   margin-bottom: 8px;
   cursor: pointer;
+  color: inherit;
+  text-decoration: none;
 
   // 编辑态：恢复默认光标
   &.editing {
@@ -483,6 +506,10 @@ const starBookmark = async (isStar: boolean) => {
       var(--slax-shadow-warm),
       inset 0 1px 0 var(--slax-inset-hi, rgba(255, 255, 255, 0.06));
     transform: translateY(-1px);
+
+    .article-title {
+      color: var(--slax-accent);
+    }
   }
 
   // 删除动画
@@ -496,6 +523,13 @@ const starBookmark = async (isStar: boolean) => {
   }
 }
 
+.article-card-link {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
 // 序号：衬线字体，右对齐，固定宽度
 // 不设 line-height 防与标题错位
 .article-num {
@@ -507,16 +541,19 @@ const starBookmark = async (isStar: boolean) => {
   text-align: right;
   flex-shrink: 0;
   user-select: none;
+  pointer-events: none;
 }
 
 // 内容区：flex-1，右侧留出星标空间
 .article-body {
+  position: relative;
+  z-index: 1;
   flex: 1;
   min-width: 0;
   padding-right: 24px;
+  pointer-events: none;
 }
 
-// 标题外层容器：控制截断，让 button 宽度由文字决定
 .title-wrap {
   display: block;
   width: 100%;
@@ -524,7 +561,6 @@ const starBookmark = async (isStar: boolean) => {
   margin-bottom: 8px;
 }
 
-// 标题按钮
 .article-title {
   // 单行标题，超出省略号
   display: block;
@@ -533,6 +569,7 @@ const starBookmark = async (isStar: boolean) => {
   background: transparent;
   border: none;
   padding: 0;
+  text-decoration: none;
   font-family: var(--slax-font-serif);
   font-size: 17px;
   font-weight: 400;
@@ -547,6 +584,7 @@ const starBookmark = async (isStar: boolean) => {
   // va:bottom 会裁中文字顶，不用
   transition: color 0.12s;
   position: relative;
+  pointer-events: auto;
 
   &:hover {
     color: var(--slax-accent);
@@ -585,6 +623,7 @@ const starBookmark = async (isStar: boolean) => {
   transition:
     border-color 0.15s,
     box-shadow 0.15s;
+  pointer-events: auto;
 
   &:focus {
     border-color: var(--slax-accent);
@@ -628,6 +667,8 @@ const starBookmark = async (isStar: boolean) => {
   cursor: pointer;
   flex-shrink: 1;
   transition: all 0.12s;
+  text-decoration: none;
+  pointer-events: auto;
 
   &:hover {
     color: var(--slax-accent);
@@ -643,6 +684,7 @@ const starBookmark = async (isStar: boolean) => {
   opacity: 0;
   transition: opacity 0.15s;
   flex-shrink: 0;
+  pointer-events: auto;
 
   .article-card:hover & {
     opacity: 1;
@@ -677,6 +719,7 @@ const starBookmark = async (isStar: boolean) => {
 // 星标按钮：绝对定位右侧
 .article-star {
   position: absolute;
+  z-index: 1;
   right: 0;
   top: 16px;
   height: 28px;

--- a/apps/slax-reader-dweb/layers/core/styles/theme.css
+++ b/apps/slax-reader-dweb/layers/core/styles/theme.css
@@ -28,6 +28,12 @@ body {
   -webkit-backdrop-filter: none !important;
 }
 
+/* E-ink source hover */
+html[data-slax-theme='eink'] .article-card .article-source:hover {
+  color: var(--slax-text) !important;
+  background-color: #b8b8b8 !important;
+}
+
 /* E-ink 关闭 Nuxt View Transition（::view-transition-* 挂在 transition root，
    不被普通 * 选择器覆盖，必须显式禁用） */
 :root[data-slax-theme='eink']::view-transition-old(*),

--- a/apps/slax-reader-dweb/tests/unit/components/Article/processors/tweet.processor.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/Article/processors/tweet.processor.spec.ts
@@ -1,34 +1,24 @@
 // TweetProcessor 单测 —— 第四期 Sprint A.1.1
-// 覆盖：仅 Twitter 风格才 match=true / tweet-header 替换 + dataset 透传 / tweet-footer 替换 + dataset 解析 / followers/replyCount 缺省转 0 / 容器无目标安全跳过
+// TweetProcessor tests
 import { TweetProcessor } from '~~/layers/core/app/components/Article/processors/tweet.processor'
 import type { WebProcessorContext } from '~~/layers/core/app/components/Article/processors/types'
 import { ArticleStyle } from '~~/layers/core/app/components/Article/processors/types'
 import { describe, expect, it, vi } from 'vitest'
 
-const userArgs: Array<Record<string, unknown>> = []
 const footerArgs: Array<Record<string, unknown>> = []
 
 vi.mock('~~/layers/core/app/components/Article/CEComponents', () => {
-  class FakeTweetUserInfo extends HTMLElement {
-    constructor(props?: Record<string, unknown>) {
-      super()
-      if (props) userArgs.push(props)
-    }
-  }
   class FakeTweetFooterInfo extends HTMLElement {
     constructor(props?: Record<string, unknown>) {
       super()
       if (props) footerArgs.push(props)
     }
   }
-  if (!customElements.get('fake-tweet-user-info')) {
-    customElements.define('fake-tweet-user-info', FakeTweetUserInfo)
-  }
   if (!customElements.get('fake-tweet-footer-info')) {
     customElements.define('fake-tweet-footer-info', FakeTweetFooterInfo)
   }
   return {
-    TweetUserInfoElement: FakeTweetUserInfo,
+    TweetUserInfoElement: class {},
     TweetFooterInfoElement: FakeTweetFooterInfo,
     UnsupportedVideoElement: class {},
     WechatVideoInfoElement: class {},
@@ -59,26 +49,13 @@ describe('TweetProcessor', () => {
     expect(processor.match(buildContext('', ArticleStyle.Default))).toBe(false)
   })
 
-  it('tweet-header 替换 + dataset 透传 + 数字缺省 0', () => {
-    userArgs.length = 0
+  it('移除 tweet-header 作者详情', () => {
     const ctx = buildContext(
       '<tweet-header data-href="https://x.com/u" data-avatar="a" data-name="N" data-description="d" data-screen-name="sn" data-location="loc" data-website="w" data-created-at="c" data-followers="123"></tweet-header>'
     )
     processor.process(ctx)
     expect(ctx.container.querySelector('tweet-header')).toBeNull()
-    expect(userArgs).toHaveLength(1)
-    expect(userArgs[0]).toMatchObject({
-      href: 'https://x.com/u',
-      avatar: 'a',
-      name: 'N',
-      description: 'd',
-      screenName: 'sn',
-      location: 'loc',
-      website: 'w',
-      createdAt: 'c',
-      followers: 123,
-      followings: 0
-    })
+    expect(ctx.container.textContent).toBe('')
   })
 
   it('tweet-footer 替换 + 数字解析 + 数字缺省 0', () => {

--- a/apps/slax-reader-dweb/tests/unit/components/BookmarkList/BookmarkCell.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/BookmarkList/BookmarkCell.spec.ts
@@ -69,6 +69,8 @@ describe('components/BookmarkList/BookmarkCell', () => {
       expect(wrapper.find('.article-title').text()).toBe(baseBookmarkItem.title)
       expect(wrapper.find('.article-source').text()).toBe('Example Site')
       expect(wrapper.find('.article-date').text()).toBe('2026-01-01')
+      expect(wrapper.find('.article-card-link').attributes('href')).toBe('/bookmarks/1000001')
+      expect(wrapper.find('.article-title').attributes('href')).toBe('/bookmarks/1000001')
       // 操作按钮：编辑 + 归档 + 删除 = 3 个
       expect(wrapper.findAll('.article-action').length).toBe(3)
     })

--- a/apps/slax-reader-extensions/src/entrypoints/background/browserService.ts
+++ b/apps/slax-reader-extensions/src/entrypoints/background/browserService.ts
@@ -29,8 +29,6 @@ export class BrowserService {
 
   static registerContextMenus(): void {
     const menus: Browser.contextMenus.CreateProperties[] = [
-      { id: 'setting', title: i18n.t('extended_settings'), contexts: ['action'] },
-      { id: 'shortcutKeySetting', title: i18n.t('shortcut_settings'), contexts: ['action'] },
       { id: 'collectList', title: i18n.t('slax_collection_list'), contexts: ['action'] },
       { id: 'collect', title: i18n.t('collect_page'), contexts: ['page'] }
     ]

--- a/apps/slax-reader-extensions/src/locales/en.json
+++ b/apps/slax-reader-extensions/src/locales/en.json
@@ -143,7 +143,7 @@
   "removal_in_progress": "Removing",
   "removal_successful": "Removed",
   "shortcut_settings": "Shortcut Settings",
-  "slax_collection_list": "Slax Collection List",
+  "slax_collection_list": "Slax Inbox ↗",
   "util": {
     "chatbot": {
       "browser_finished": "Access complete",

--- a/apps/slax-reader-extensions/src/locales/zh_CN.json
+++ b/apps/slax-reader-extensions/src/locales/zh_CN.json
@@ -143,7 +143,7 @@
   "removal_in_progress": "移除中",
   "removal_successful": "已移除",
   "shortcut_settings": "快捷键设置",
-  "slax_collection_list": "Slax 收藏列表",
+  "slax_collection_list": "Slax 收件箱 ↗",
   "util": {
     "chatbot": {
       "browser_finished": "访问完成",


### PR DESCRIPTION
## Summary
- remove Twitter author details from article rendering
- make inbox cards expose native copy-link actions
- improve card title and E-ink source hover states
- simplify the extension action menu and rename the inbox entry

## Validation
- 40 targeted dweb tests passed
- ESLint passed for changed source and test files
- JSON and diff checks passed