### PR TITLE
✨ inbox source filter + UI polish

### DIFF
--- a/apps/slax-reader-dweb/.nuxtrc
+++ b/apps/slax-reader-dweb/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@nuxt/test-utils="4.0.3"
+setups.@nuxt/test-utils="4.2.0"

--- a/apps/slax-reader-dweb/layers/core/app/components/Article/BookmarkArticle.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/BookmarkArticle.vue
@@ -1,13 +1,16 @@
 <template>
   <div class="bookmark-article snapshot" ref="bookmarkArticle" :class="{ [articleStyle]: true }">
     <header class="article-header">
-      <SnapshotArticleSource v-if="detail.target_url" :url="detail.target_url" />
+      <SnapshotArticleSource
+        v-if="detail.target_url"
+        :url="detail.target_url"
+        :site-name="detail.site_name"
+        :column-name="(detail as BookmarkArticleDetail & { column_name?: string }).column_name"
+        :author="detail.byline"
+        :host-url="detail.host_url"
+      />
       <div class="article-divider" />
       <h1 class="article-title" :title="title">{{ title }}</h1>
-      <div class="article-info">
-        <span v-if="detail.byline" class="article-author">{{ detail.byline }}</span>
-        <time class="article-date">{{ dateString }}</time>
-      </div>
       <BookmarkTags
         v-if="effAllowTagged"
         class="article-tags"
@@ -36,7 +39,6 @@ import { registerComponents } from './CEComponents'
 import { ArticleStyle } from './processors'
 import { ArticleSelectionAdaptersKey } from './Selection/injection'
 import type { MarkDetail } from '@commons/types/interface'
-import { formatDate } from '@vueuse/core'
 import type { QuoteData } from '#layers/core/app/components/Chat/type'
 import CursorToast from '#layers/core/app/components/CursorToast'
 import Toast, { ToastType } from '#layers/core/app/components/Toast'
@@ -108,13 +110,6 @@ const articleStyle = computed(() => {
   }
 
   return ArticleStyle.Default
-})
-
-const dateString = computed(() => {
-  const date = detail.value.created_at ?? ''
-  if (!date) return ''
-
-  return t('page.bookmarks_detail.saved_at', { date: formatDate(new Date(date), 'YYYY-MM-DD') })
 })
 
 const articleHTML = computed(() => {
@@ -242,22 +237,6 @@ defineExpose({
     padding: 2px 6px;
     margin-left: -6px;
     cursor: text;
-  }
-}
-
-.article-info {
-  --style: flex items-center flex-wrap gap-x-16px gap-y-4px;
-
-  .article-author {
-    font-size: 14px;
-    color: var(--slax-text-muted);
-    font-weight: 400;
-  }
-
-  .article-date {
-    font-size: 13px;
-    font-weight: 300;
-    color: var(--slax-text-light);
   }
 }
 

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkCell.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkCell.vue
@@ -1,7 +1,14 @@
 <template>
   <!-- 卡片条目：点击整卡跳快照 -->
   <div class="article-card" :class="{ deleting: isDeleting, editing: isEditingTitle }">
-    <a class="article-card-link" :href="articleHref" target="_blank" rel="noopener noreferrer" :aria-label="bookmark.alias_title || bookmark.title" @click.stop.prevent="clickCard"></a>
+    <a
+      class="article-card-link"
+      :href="articleHref"
+      target="_blank"
+      rel="noopener noreferrer"
+      :aria-label="bookmark.alias_title || bookmark.title"
+      @click.stop.prevent="clickCard"
+    ></a>
     <!-- 序号 -->
     <span class="article-num">{{ index !== undefined ? index + 1 : '' }}</span>
 
@@ -41,12 +48,18 @@
       <!-- meta 行：日期 + 来源 + hover 操作区 -->
       <div class="article-meta">
         <span class="article-date">{{ dateString }}</span>
-        <a class="article-source" :href="articleHref" target="_blank" rel="noopener noreferrer" @click.stop.prevent="clickHref">{{ getSiteName() }}</a>
+        <button v-if="sourceFilterable && sourceDomain" class="article-source" type="button" @click.stop="selectSource">{{ getSiteName() }}</button>
+        <a v-else class="article-source" :href="originalHref" target="_blank" rel="noopener noreferrer" @click.stop="clickHref">{{ getSiteName() }}</a>
 
         <!-- hover 操作区 -->
         <div class="article-actions">
+          <!-- 打开原文 -->
+          <button v-if="sourceFilterable && sourceDomain" class="article-action open-original" @click.stop="clickHref" type="button">
+            {{ $t('common.operate.open_original') }}
+          </button>
+
           <!-- 编辑标题 -->
-          <button class="article-action" ref="editTitleButton" @click.stop="clickEdit" type="button">
+          <button class="article-action edit-title" ref="editTitleButton" @click.stop="clickEdit" type="button">
             {{ !isEditingTitle ? $t('common.operate.edit_title') : $t('common.operate.cancel_edit_title') }}
           </button>
 
@@ -95,6 +108,7 @@
 import { inject } from 'vue'
 
 import { urlHttpString } from '@commons/utils/string'
+import { getBookmarkSourceDomain } from '#layers/core/app/utils/bookmarkSource'
 import { truncateTitle } from '#layers/core/app/utils/string'
 
 import { RESTMethodPath } from '@commons/types/const'
@@ -122,11 +136,21 @@ const props = defineProps({
   collectionCode: {
     type: String,
     required: false
+  },
+  sourceFilterable: {
+    type: Boolean,
+    default: false
   }
 })
 
 const { index, bookmark } = toRefs(props)
-const emits = defineEmits(['delete', 'archiveUpdate', 'aliasTitleUpdate', 'bookmarkUpdate'])
+const emits = defineEmits<{
+  delete: [id: number]
+  archiveUpdate: [id: number, archive: boolean]
+  aliasTitleUpdate: [id: number, aliasTitle: string]
+  bookmarkUpdate: [id: number, bookmark: BookmarkItem]
+  sourceFilter: [source: { domain: string; label: string }]
+}>()
 
 // local-first 可写；null 则回退 REST
 // local tab 下 id 即本地 uuid
@@ -219,8 +243,19 @@ const clickEdit = () => {
 }
 
 const getSiteName = () => {
-  const siteName = bookmark.value.site_name || bookmark.value.host_url
+  const siteName = bookmark.value.site_name || bookmark.value.host_url || getBookmarkSourceDomain(bookmark.value)
   return bookmark.value.type === 'shortcut' ? t('component.bookmark_cell.shortcut') + ' ' + siteName : siteName
+}
+
+const sourceDomain = computed(() => getBookmarkSourceDomain(bookmark.value))
+const originalHref = computed(() => urlHttpString(bookmark.value.target_url))
+
+const selectSource = () => {
+  if (isRequesting.value) return
+  const domain = sourceDomain.value
+  if (!domain) return
+  trackListItemInteract('source_filter')
+  emits('sourceFilter', { domain, label: getSiteName() || domain })
 }
 
 const articleHref = computed(() => {
@@ -653,8 +688,11 @@ const starBookmark = async (isStar: boolean) => {
   white-space: nowrap;
 }
 
-// 来源标签：胶囊形，点击跳转原链接
+// 来源：胶囊形
 .article-source {
+  border: none;
+  font-family: inherit;
+  line-height: inherit;
   font-size: 12px;
   color: var(--slax-text-muted);
   background: var(--slax-accent-bg);

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkListContent.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkListContent.vue
@@ -171,6 +171,10 @@ const emit = defineEmits<{
     margin-left: 0;
     color: var(--slax-text-light);
     font-weight: 300;
+
+    &:hover {
+      color: var(--slax-accent);
+    }
   }
 
   // 星标：缩小 icon，绝对定位并与标题垂直居中
@@ -240,6 +244,10 @@ const emit = defineEmits<{
       color: var(--slax-text-light);
       padding: 0 0 0 8px;
       max-width: 54vw;
+
+      &:hover {
+        color: var(--slax-accent);
+      }
     }
 
     .article-actions {

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkListContent.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkListContent.vue
@@ -16,7 +16,9 @@
                 :is-subscribe="filterStatus === 'collections'"
                 :bookmark="item.bookmark"
                 :collection-code="filterCollectionCode"
+                :source-filterable="filterStatus === 'inbox'"
                 :class="{ 'text-mode': effectiveMode === 'text' }"
+                @source-filter="source => emit('source-filter', source)"
                 @delete="(id: number) => emit('delete', id)"
                 @archive-update="(id: number, archive: boolean) => emit('archive-update', id, archive)"
                 @alias-title-update="(id: number, aliasTitle: string) => emit('alias-title-update', id, aliasTitle)"
@@ -34,7 +36,9 @@
               :is-subscribe="filterStatus === 'collections'"
               :bookmark="item.bookmark"
               :collection-code="filterCollectionCode"
+              :source-filterable="filterStatus === 'inbox'"
               :class="{ 'text-mode': effectiveMode === 'text' }"
+              @source-filter="source => emit('source-filter', source)"
               @delete="(id: number) => emit('delete', id)"
               @archive-update="(id: number, archive: boolean) => emit('archive-update', id, archive)"
               @alias-title-update="(id: number, aliasTitle: string) => emit('alias-title-update', id, aliasTitle)"
@@ -90,6 +94,7 @@ const emit = defineEmits<{
   'archive-update': [id: number, archive: boolean]
   'alias-title-update': [id: number, aliasTitle: string]
   'bookmark-update': [id: number, bookmark: BookmarkItem]
+  'source-filter': [source: { domain: string; label: string }]
 }>()
 </script>
 

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksEmptyView.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksEmptyView.vue
@@ -34,6 +34,8 @@ const emit = defineEmits<{ action: [] }>()
   justify-content: center;
   text-align: center;
   padding: 96px 24px 48px;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .empty-view-icon {

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/ListLayoutSwitcher.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/ListLayoutSwitcher.vue
@@ -1,8 +1,10 @@
 <template>
   <!-- 列表工具栏：最近更新时间 + 布局切换器（card / text）。显隐 guard 由父级控制 -->
-  <div class="page-toolbar">
-    <p class="page-subtitle" v-if="lastUpdatedText">{{ lastUpdatedText }}</p>
-    <div v-else />
+  <div class="page-toolbar" :class="{ 'has-leading': showLeading }">
+    <div class="toolbar-leading">
+      <slot v-if="showLeading" name="leading" />
+      <p class="page-subtitle" v-else-if="lastUpdatedText">{{ lastUpdatedText }}</p>
+    </div>
     <div class="layout-switcher">
       <!-- 文字列表：三条横线 icon -->
       <button class="layout-btn" :class="{ active: listMode === 'text' }" @click="listMode = 'text'" :title="$t('page.bookmarks_index.layout_text')" type="button">
@@ -25,6 +27,7 @@
 <script setup lang="ts">
 defineProps<{
   lastUpdatedText: string
+  showLeading?: boolean
 }>()
 
 // 布局模式：'card'（卡片）| 'text'（紧凑文字），由父级 v-model 持久化
@@ -38,7 +41,20 @@ const listMode = defineModel<'card' | 'text'>({ required: true })
   // ≤768：隐藏布局切换器
   @media (max-width: 768px) {
     display: none;
+
+    // 移动端保留来源筛选关闭入口
+    &.has-leading {
+      display: flex;
+
+      .layout-switcher {
+        display: none;
+      }
+    }
   }
+}
+
+.toolbar-leading {
+  min-width: 0;
 }
 
 .page-subtitle {

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/SearchHeader.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/SearchHeader.vue
@@ -29,9 +29,19 @@
     <ListEndHint v-if="!isSearching && searchResults.length > 0" class="search-end" :text="$t('page.bookmarks_index.no_more')" />
 
     <!-- 空态 -->
-    <div class="search-empty" v-if="!isSearching && searchResults.length === 0 && defaultSearchText">
-      {{ $t('component.search_header.empty') }}
-    </div>
+    <BookmarksEmptyView
+      v-if="!isSearching && searchResults.length === 0 && defaultSearchText"
+      class="search-empty"
+      :title="$t('component.search_header.empty')"
+      :desc="$t('component.search_header.empty_desc')"
+    >
+      <template #icon>
+        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <circle cx="11" cy="11" r="7" />
+          <path d="m20 20-4-4" />
+        </svg>
+      </template>
+    </BookmarksEmptyView>
 
     <!-- 加载中 -->
     <div class="search-loading" v-if="isSearching">
@@ -41,6 +51,7 @@
 </template>
 
 <script lang="ts" setup>
+import BookmarksEmptyView from '#layers/core/app/components/BookmarkList/BookmarksEmptyView.vue'
 import ListEndHint from '#layers/core/app/components/ListEndHint.vue'
 
 import { RESTMethodPath } from '@commons/types/const'
@@ -229,13 +240,6 @@ const search = async (text: string) => {
 
 .search-end {
   margin-top: 32px;
-}
-
-.search-empty {
-  padding: 48px 0;
-  text-align: center;
-  color: var(--slax-text-light);
-  font-size: 14px;
 }
 
 .search-loading {

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/TagsHeader.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/TagsHeader.vue
@@ -51,6 +51,20 @@
           </div>
         </div>
       </div>
+
+      <BookmarksEmptyView
+        v-if="!isTagLoading && tags.length === 0"
+        class="tags-empty"
+        :title="$t('page.bookmarks_index.empty_topics_title')"
+        :desc="$t('page.bookmarks_index.empty_topics_desc')"
+      >
+        <template #icon>
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M20.59 13.41 11 3.83V3H4v7h.83l9.58 9.59a2 2 0 0 0 2.82 0l3.36-3.36a2 2 0 0 0 0-2.82Z" />
+            <circle cx="7.5" cy="6.5" r="1" />
+          </svg>
+        </template>
+      </BookmarksEmptyView>
     </template>
 
     <!-- 已选标签：显示返回 + 标签名 -->
@@ -66,6 +80,8 @@
 </template>
 
 <script lang="ts" setup>
+import BookmarksEmptyView from '#layers/core/app/components/BookmarkList/BookmarksEmptyView.vue'
+
 import { RESTMethodPath } from '@commons/types/const'
 import type { BookmarkTag } from '@commons/types/interface'
 import { vOnKeyStroke } from '@vueuse/components'

--- a/apps/slax-reader-dweb/layers/core/app/components/Chat/ChatBot.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Chat/ChatBot.vue
@@ -519,17 +519,23 @@ const onKeyDown = (e: KeyboardEvent) => {
     return
   }
 
-  const commonPreLineKey = e.ctrlKey || e.shiftKey
-  if ((commonPreLineKey && !isMac) || ((commonPreLineKey || e.metaKey) && isMac)) {
+  // Shift+Enter 交给浏览器原生处理
+  if (e.shiftKey) {
+    return
+  }
+
+  const preLineKey = isMac ? e.metaKey : e.ctrlKey
+  if (preLineKey) {
     if (!e.target || !(e.target instanceof HTMLTextAreaElement)) {
       return
     }
 
+    // Ctrl/Cmd+Enter 手动插入换行
     const textareaTarget = e.target as HTMLTextAreaElement
     const cursorPosition = textareaTarget.selectionStart
     const textBeforeCursor = inputText.value.slice(0, cursorPosition)
     const textAfterCursor = inputText.value.slice(cursorPosition)
-    !e.shiftKey && (inputText.value = textBeforeCursor + '\n' + textAfterCursor)
+    inputText.value = textBeforeCursor + '\n' + textAfterCursor
 
     nextTick(() => {
       textareaTarget.selectionStart = cursorPosition + 1

--- a/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotArticleSource.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotArticleSource.vue
@@ -1,12 +1,22 @@
 <template>
   <a class="article-source" :href="href" target="_blank" rel="noopener noreferrer" :title="url">
-    <span class="article-source-label">{{ $t('component.chat_bubble_message.links_source') }}</span>
-    <span class="article-source-url">{{ displayUrl }}</span>
+    <span class="article-source-label">{{ $t('component.snapshot_article_source.label') }}</span>
+    <span class="article-source-name" :title="sourceName">{{ sourceName }}</span>
+    <span v-if="authorName" class="article-source-separator">·</span>
+    <span v-if="authorName" class="article-source-author" :title="authorName">{{ authorName }}</span>
+    <span class="article-source-external" aria-hidden="true">↗</span>
   </a>
 </template>
 
 <script lang="ts" setup>
-const props = defineProps<{ url: string }>()
+const props = defineProps<{
+  url: string
+  /** Parsed publication/column name. A future column_name can be passed here with priority. */
+  siteName?: string | null
+  columnName?: string | null
+  author?: string | null
+  hostUrl?: string | null
+}>()
 
 // 无协议时补 https://
 const href = computed(() => {
@@ -15,13 +25,35 @@ const href = computed(() => {
   return /^https?:\/\//i.test(url) ? url : `https://${url}`
 })
 
-const displayUrl = computed(() => {
+const hostname = computed(() => {
+  const raw = props.hostUrl?.trim() || props.url?.trim() || ''
   try {
-    const u = new URL(href.value)
-    return u.hostname.replace(/^www\./, '') + u.pathname.replace(/\/$/, '')
+    return new URL(/^[a-z][a-z\d+.-]*:\/\//i.test(raw) ? raw : `https://${raw}`).hostname.replace(/^www\./i, '')
   } catch {
-    return props.url
+    return raw
+      .replace(/^[a-z][a-z\d+.-]*:\/\//i, '')
+      .split('/')[0]
+      .replace(/^www\./i, '')
   }
+})
+
+const isX = computed(() => /(^|\.)x\.com$|(^|\.)twitter\.com$/i.test(hostname.value))
+
+const sourceName = computed(() => {
+  // columnName 优先，前向兼容未来的 column 字段
+  const parsed = props.columnName?.trim() || props.siteName?.trim()
+  if (parsed) return isX.value && /^(twitter|x)$/i.test(parsed) ? 'X' : parsed
+  return hostname.value || props.url
+})
+
+const authorName = computed(() => {
+  if (isX.value) {
+    // X 的作者从 URL 提取
+    const match = props.url?.match(/(?:x|twitter)\.com\/([^/?#]+)/i)
+    const handle = match?.[1] && !/^i$/i.test(match[1]) ? match[1] : ''
+    if (handle) return handle.startsWith('@') ? handle : `@${handle}`
+  }
+  return props.author?.trim() || ''
 })
 </script>
 
@@ -29,31 +61,51 @@ const displayUrl = computed(() => {
 .article-source {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  max-width: 280px;
+  gap: 5px;
+  max-width: min(100%, 520px);
   width: fit-content;
-  padding: 2px 10px;
-  font-size: 12px;
+  padding: 3px 0;
+  font-size: 13px;
   font-weight: 400;
   color: var(--slax-text-muted);
-  background: var(--slax-accent-bg);
-  border-radius: 20px;
   text-decoration: none;
   transition: all 0.15s;
 
   &:hover {
-    background: color-mix(in srgb, var(--slax-accent) 10%, transparent);
+    color: var(--slax-accent);
   }
 
   .article-source-label {
     flex-shrink: 0;
   }
 
-  .article-source-url {
+  .article-source-name,
+  .article-source-author {
     color: var(--slax-accent);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .article-source-name {
+    font-weight: 500;
+  }
+
+  .article-source-separator {
+    flex-shrink: 0;
+    color: var(--slax-text-muted);
+  }
+
+  .article-source-author {
+    color: var(--slax-text-muted);
+  }
+
+  .article-source-external {
+    flex-shrink: 0;
+    margin-left: 1px;
+    color: currentColor;
+    font-size: 14px;
+    line-height: 1;
   }
 }
 </style>

--- a/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotArticleSource.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotArticleSource.vue
@@ -64,15 +64,18 @@ const authorName = computed(() => {
   gap: 5px;
   max-width: min(100%, 520px);
   width: fit-content;
-  padding: 3px 0;
-  font-size: 13px;
+  padding: 3px 10px;
+  font-size: 12px;
   font-weight: 400;
   color: var(--slax-text-muted);
+  background: var(--slax-accent-bg);
+  border-radius: 20px;
   text-decoration: none;
   transition: all 0.15s;
 
   &:hover {
     color: var(--slax-accent);
+    background: color-mix(in srgb, var(--slax-accent) 10%, transparent);
   }
 
   .article-source-label {
@@ -93,10 +96,6 @@ const authorName = computed(() => {
 
   .article-source-separator {
     flex-shrink: 0;
-    color: var(--slax-text-muted);
-  }
-
-  .article-source-author {
     color: var(--slax-text-muted);
   }
 

--- a/apps/slax-reader-dweb/layers/core/app/composables/bookmark/useBookmarkCellNavigation.ts
+++ b/apps/slax-reader-dweb/layers/core/app/composables/bookmark/useBookmarkCellNavigation.ts
@@ -7,7 +7,7 @@ import { showSnapshotStatusModal } from '#layers/core/app/components/Modal'
 
 type ListSection = 'inbox' | 'starred' | 'topics' | 'archive' | 'trash' | 'notifications'
 
-type InteractElement = 'title' | 'orginal' | 'snapshot' | 'edit_title' | 'star' | 'archive' | 'trash'
+type InteractElement = 'title' | 'orginal' | 'snapshot' | 'source_filter' | 'edit_title' | 'star' | 'archive' | 'trash'
 
 export interface UseBookmarkCellNavigationOptions {
   bookmark: Ref<BookmarkItem>

--- a/apps/slax-reader-dweb/layers/core/app/utils/bookmarkSource.ts
+++ b/apps/slax-reader-dweb/layers/core/app/utils/bookmarkSource.ts
@@ -1,0 +1,19 @@
+import type { BookmarkItem } from '@commons/types/interface'
+
+type BookmarkSource = Pick<BookmarkItem, 'host_url' | 'target_url'>
+
+export const normalizeSourceDomain = (value?: string | null): string => {
+  const source = value?.trim()
+  if (!source) return ''
+
+  try {
+    const url = new URL(/^https?:\/\//i.test(source) ? source : `https://${source}`)
+    return url.hostname.toLowerCase().replace(/\.$/, '')
+  } catch {
+    return ''
+  }
+}
+
+export const getBookmarkSourceDomain = (bookmark: BookmarkSource): string => normalizeSourceDomain(bookmark.host_url) || normalizeSourceDomain(bookmark.target_url)
+
+export const bookmarkMatchesSourceDomain = (bookmark: BookmarkSource, domain: string): boolean => getBookmarkSourceDomain(bookmark) === normalizeSourceDomain(domain)

--- a/apps/slax-reader-dweb/layers/core/i18n/locales/en.json
+++ b/apps/slax-reader-dweb/layers/core/i18n/locales/en.json
@@ -76,6 +76,7 @@
       "more": "More",
       "off": "OFF",
       "on": "ON",
+      "open_original": "Open original",
       "payment": {
         "completed": "Payment Completed",
         "confirm_desc": "Have you completed the payment?",
@@ -257,6 +258,9 @@
       "bookmarks_source": "Bookmark source:",
       "links_source": "Information source:",
       "related_questions": "Related:"
+    },
+    "snapshot_article_source": {
+      "label": "Source:"
     },
     "chat_tips_message": {
       "generate_question_title": "You might want to ask..."

--- a/apps/slax-reader-dweb/layers/core/i18n/locales/zh.json
+++ b/apps/slax-reader-dweb/layers/core/i18n/locales/zh.json
@@ -76,6 +76,7 @@
       "more": "更多",
       "off": "已关闭",
       "on": "已开启",
+      "open_original": "打开原文",
       "payment": {
         "completed": "已完成支付",
         "confirm_desc": "您是否已完成支付？",
@@ -257,6 +258,9 @@
       "bookmarks_source": "书签来源：",
       "links_source": "信息来源：",
       "related_questions": "相关的："
+    },
+    "snapshot_article_source": {
+      "label": "来源："
     },
     "chat_tips_message": {
       "generate_question_title": "读者最关心："

--- a/apps/slax-reader-dweb/tests/integration/components/Article/BookmarkArticle.spec.ts
+++ b/apps/slax-reader-dweb/tests/integration/components/Article/BookmarkArticle.spec.ts
@@ -1,5 +1,5 @@
 // BookmarkArticle.vue 集成测试 —— 第五期 Sprint B.1
-// 覆盖：渲染（title/byline/date/url/star）/ articleStyle 三种风格 / dateString 三分支 / urlString 计算 /
+// 覆盖：渲染（title/source/star）/ articleStyle 三种风格 /
 //      starBookmark（成功/失败 + Toast）/ websiteClick / handleHTML（DOMPipeline run）/ handleDrawMark / jumpToHighLight
 // 关键约束：
 //  - 真实依赖按 phase5-plan §B.1 修订 4 mock 链路（含 ToastType / processors 13+ArticleStyle/DOMPipeline / Toast/CursorToast/ImagePreview）
@@ -21,9 +21,7 @@ const {
   mockNavigateTo,
   mockPostChannelMessage,
   mockRequest,
-  mockPost,
   mockUseI18n,
-  mockT,
   mockUseArticleDetail,
   mockArticleDetailReturn,
   mockToastShowToast,
@@ -203,7 +201,12 @@ vi.mock('@commons/types/interface', async () => {
 
 // BookmarkTags 子组件 stub（避免引入 BookmarkTags spec 的 mock 链）
 const stubs = {
-  BookmarkTags: { name: 'BookmarkTags', template: '<div class="bookmark-tags-stub" />', props: ['bookmarkId', 'tags', 'readonly'] }
+  BookmarkTags: { name: 'BookmarkTags', template: '<div class="bookmark-tags-stub" />', props: ['bookmarkId', 'tags', 'readonly'] },
+  SnapshotArticleSource: {
+    name: 'SnapshotArticleSource',
+    template: '<div class="article-source-stub" />',
+    props: ['url', 'siteName', 'columnName', 'author', 'hostUrl']
+  }
 }
 
 function buildDetail(overrides: Record<string, unknown> = {}) {
@@ -254,12 +257,14 @@ afterEach(() => {
 
 describe('Article/BookmarkArticle', () => {
   describe('渲染', () => {
-    it('mount → 渲染 .bookmark-article + title + byline + date', () => {
+    it('mount → 渲染 .bookmark-article + title + source', () => {
       const wrapper = mountWithApp(BookmarkArticle, { props: { detail: buildDetail() }, global: { stubs } })
       expect(wrapper.find('.bookmark-article').exists()).toBe(true)
       expect(wrapper.find('.article-title').text()).toBe('Test Title')
-      expect(wrapper.find('.article-author').text()).toBe('Author')
-      expect(wrapper.find('.article-date').text()).toBe('First saved on 2026-01-01')
+      expect(wrapper.findComponent({ name: 'SnapshotArticleSource' }).props()).toMatchObject({
+        url: 'https://example.com/article',
+        author: 'Author'
+      })
     })
 
     it('article-detail v-html 渲染 detail.content 并补 lazy loading', () => {
@@ -284,10 +289,9 @@ describe('Article/BookmarkArticle', () => {
       expect(wrapper.find('.star').exists()).toBe(false)
     })
 
-    it('detail.byline 为空：不渲染 .article-author', () => {
+    it('detail.byline 为空：source author 为空', () => {
       const wrapper = mountWithApp(BookmarkArticle, { props: { detail: buildDetail({ byline: '' }) }, global: { stubs } })
-      expect(wrapper.find('.article-author').exists()).toBe(false)
-      expect(wrapper.find('.article-date').text()).toBe('First saved on 2026-01-01')
+      expect(wrapper.findComponent({ name: 'SnapshotArticleSource' }).props('author')).toBe('')
     })
   })
 
@@ -316,26 +320,6 @@ describe('Article/BookmarkArticle', () => {
         global: { stubs }
       })
       expect(wrapper.find('.article-detail').classes()).toContain('default')
-    })
-  })
-
-  describe('dateString computed', () => {
-    // dateString 现仅取 created_at（published_at 分支已从源码移除），
-    // 缺失时返回空串（无 '--' 兜底）
-    it('created_at 存在：格式化为 YYYY-MM-DD 并套 saved_at 文案', () => {
-      const wrapper = mountWithApp(BookmarkArticle, {
-        props: { detail: buildDetail({ created_at: '2024-06-15T00:00:00.000Z' }) },
-        global: { stubs }
-      })
-      expect(wrapper.find('.article-date').text()).toBe('First saved on 2024-06-15')
-    })
-
-    it('created_at 缺失：返回空串', () => {
-      const wrapper = mountWithApp(BookmarkArticle, {
-        props: { detail: buildDetail({ created_at: undefined }) },
-        global: { stubs }
-      })
-      expect(wrapper.find('.article-date').text()).toBe('')
     })
   })
 

--- a/apps/slax-reader-dweb/tests/unit/components/BookmarkList/BookmarkCell.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/BookmarkList/BookmarkCell.spec.ts
@@ -71,7 +71,7 @@ describe('components/BookmarkList/BookmarkCell', () => {
       expect(wrapper.find('.article-date').text()).toBe('2026-01-01')
       expect(wrapper.find('.article-card-link').attributes('href')).toBe('/bookmarks/1000001')
       expect(wrapper.find('.article-title').attributes('href')).toBe('/bookmarks/1000001')
-      // 操作按钮：编辑 + 归档 + 删除 = 3 个
+      // 非 inbox：编辑 + 归档 + 删除 = 3 个
       expect(wrapper.findAll('.article-action').length).toBe(3)
     })
 
@@ -90,7 +90,6 @@ describe('components/BookmarkList/BookmarkCell', () => {
     it('isTrashed=true：渲染恢复按钮 + 不渲染删除按钮', () => {
       const bm = makeBookmarkItem({ trashed_at: '2026-01-02T00:00:00.000Z' })
       const wrapper = mountWithApp(BookmarkCell, { props: { bookmark: bm, isSubscribe: false } })
-      // isTrashed=true：[0]=编辑, [1]=恢复，无 danger 按钮
       expect(wrapper.findAll('.article-action').length).toBe(2)
       expect(wrapper.find('.article-action.danger').exists()).toBe(false)
       expect(wrapper.find('.article-date').text()).toBe('2026-01-02')
@@ -107,7 +106,6 @@ describe('components/BookmarkList/BookmarkCell', () => {
         props: { bookmark: baseBookmarkItem, isSubscribe: true, collectionCode: 'COL1' }
       })
       expect(wrapper.find('.article-star').exists()).toBe(false)
-      // isSubscribe=true：只有编辑按钮，无归档/删除
       expect(wrapper.findAll('.article-action').length).toBe(1)
     })
 
@@ -185,6 +183,30 @@ describe('components/BookmarkList/BookmarkCell', () => {
     })
   })
 
+  describe('来源筛选 + 打开原文', () => {
+    it('sourceFilterable=true：来源为按钮，点击发出规范化域名且不打开页面', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+      const bm = makeBookmarkItem({ host_url: 'https://WWW.Example.com:443/path', site_name: 'Example Site' })
+      const wrapper = mountWithApp(BookmarkCell, { props: { bookmark: bm, isSubscribe: false, sourceFilterable: true } })
+
+      expect(wrapper.find('.article-source').element.tagName).toBe('BUTTON')
+      await wrapper.find('.article-source').trigger('click')
+
+      expect(wrapper.emitted('sourceFilter')).toEqual([[{ domain: 'www.example.com', label: 'Example Site' }]])
+      expect(openSpy).not.toHaveBeenCalled()
+      expect(mockAnalyticsLog).toHaveBeenCalledWith(expect.objectContaining({ element: 'source_filter' }))
+    })
+
+    it('“打开原文”始终打开 target_url，而不是快照链接', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+      const wrapper = mountWithApp(BookmarkCell, { props: { bookmark: baseBookmarkItem, isSubscribe: false, sourceFilterable: true } })
+
+      await wrapper.find('.article-action.open-original').trigger('click')
+
+      expect(openSpy).toHaveBeenCalledWith('https://example.com/article-1', '_blank')
+    })
+  })
+
   describe('star / archive / trash / revert', () => {
     it('starBookmark：调 BOOKMARK_STAR + emit bookmarkUpdate + analyticsLog', async () => {
       mockPost.mockResolvedValueOnce({ bookmark_id: 1000001, status: 'star' })
@@ -205,8 +227,7 @@ describe('components/BookmarkList/BookmarkCell', () => {
       const wrapper = mountWithApp(BookmarkCell, {
         props: { bookmark: baseBookmarkItem, isSubscribe: false }
       })
-      // article-actions 内：[0]=编辑, [1]=归档, [2]=删除
-      const archiveBtn = wrapper.findAll('.article-action')[1]!
+      const archiveBtn = wrapper.find('.article-action:not(.open-original):not(.edit-title):not(.danger)')
       expect(archiveBtn).toBeDefined()
       await archiveBtn.trigger('click')
       await flushPromises()
@@ -221,8 +242,7 @@ describe('components/BookmarkList/BookmarkCell', () => {
       const bm = makeBookmarkItem({ archived: 'archive' })
       mockPost.mockResolvedValueOnce({ bookmark_id: 1000001, status: 'inbox' })
       const wrapper = mountWithApp(BookmarkCell, { props: { bookmark: bm, isSubscribe: false } })
-      // [0]=编辑, [1]=归档（unarchive）
-      const unarchiveBtn = wrapper.findAll('.article-action')[1]!
+      const unarchiveBtn = wrapper.find('.article-action:not(.open-original):not(.edit-title):not(.danger)')
       expect(unarchiveBtn).toBeDefined()
       await unarchiveBtn.trigger('click')
       await flushPromises()
@@ -237,7 +257,7 @@ describe('components/BookmarkList/BookmarkCell', () => {
       const wrapper = mountWithApp(BookmarkCell, {
         props: { bookmark: baseBookmarkItem, isSubscribe: false }
       })
-      const archiveBtn = wrapper.findAll('.article-action')[1]!
+      const archiveBtn = wrapper.find('.article-action:not(.open-original):not(.edit-title):not(.danger)')
       await archiveBtn.trigger('click')
       await flushPromises()
       expect(mockToastShowToast).toHaveBeenCalled()
@@ -264,8 +284,7 @@ describe('components/BookmarkList/BookmarkCell', () => {
     it('clickRevert：调 REVERT_BOOKMARK + emit delete（无 stroke）', async () => {
       const bm = makeBookmarkItem({ trashed_at: '2026-01-02T00:00:00.000Z' })
       const wrapper = mountWithApp(BookmarkCell, { props: { bookmark: bm, isSubscribe: false } })
-      // isTrashed=true 时：[0]=编辑, [1]=恢复
-      const revertBtn = wrapper.findAll('.article-action')[1]!
+      const revertBtn = wrapper.find('.article-action:not(.open-original):not(.edit-title)')
       expect(revertBtn).toBeDefined()
       await revertBtn.trigger('click')
       await flushPromises()
@@ -280,8 +299,7 @@ describe('components/BookmarkList/BookmarkCell', () => {
       const wrapper = mountWithApp(BookmarkCell, {
         props: { bookmark: baseBookmarkItem, isSubscribe: false }
       })
-      // 编辑按钮是 article-actions 中第一个 article-action
-      const editBtn = wrapper.findAll('.article-action')[0]!
+      const editBtn = wrapper.find('.article-action.edit-title')
       expect(editBtn).toBeDefined()
       await editBtn.trigger('click')
       expect(wrapper.find('input').exists()).toBe(true)
@@ -293,7 +311,7 @@ describe('components/BookmarkList/BookmarkCell', () => {
       const wrapper = mountWithApp(BookmarkCell, {
         props: { bookmark: baseBookmarkItem, isSubscribe: false }
       })
-      const editBtn = wrapper.findAll('.article-action')[0]!
+      const editBtn = wrapper.find('.article-action.edit-title')
       await editBtn.trigger('click')
       const input = wrapper.find('input')
       await input.setValue('新标题')
@@ -311,7 +329,7 @@ describe('components/BookmarkList/BookmarkCell', () => {
     it('编辑后值与原 alias_title 一致：短路不调 post，仅退出编辑态', async () => {
       const bm = makeBookmarkItem({ alias_title: '已存在' })
       const wrapper = mountWithApp(BookmarkCell, { props: { bookmark: bm, isSubscribe: false } })
-      const editBtn = wrapper.findAll('.article-action')[0]!
+      const editBtn = wrapper.find('.article-action.edit-title')
       await editBtn.trigger('click')
       const input = wrapper.find('input')
       await input.setValue('已存在')
@@ -326,7 +344,7 @@ describe('components/BookmarkList/BookmarkCell', () => {
       const wrapper = mountWithApp(BookmarkCell, {
         props: { bookmark: baseBookmarkItem, isSubscribe: false }
       })
-      const editBtn = wrapper.findAll('.article-action')[0]!
+      const editBtn = wrapper.find('.article-action.edit-title')
       await editBtn.trigger('click')
       mockPost.mockClear()
       await wrapper.find('input').trigger('keydown', { key: 'Esc' })

--- a/apps/slax-reader-dweb/tests/unit/components/BookmarkList/ListLayoutSwitcher.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/BookmarkList/ListLayoutSwitcher.spec.ts
@@ -1,0 +1,25 @@
+import ListLayoutSwitcher from '~~/layers/core/app/components/BookmarkList/ListLayoutSwitcher.vue'
+
+import { mountWithApp } from '~~/tests/setup/mount'
+import { describe, expect, it } from 'vitest'
+
+describe('components/BookmarkList/ListLayoutSwitcher', () => {
+  it('默认显示最近更新时间', () => {
+    const wrapper = mountWithApp(ListLayoutSwitcher, {
+      props: { modelValue: 'card', lastUpdatedText: 'Updated 2 minutes ago' }
+    })
+
+    expect(wrapper.find('.page-subtitle').text()).toBe('Updated 2 minutes ago')
+  })
+
+  it('showLeading=true 时用 leading slot 替换最近更新时间', () => {
+    const wrapper = mountWithApp(ListLayoutSwitcher, {
+      props: { modelValue: 'card', lastUpdatedText: 'Updated 2 minutes ago', showLeading: true },
+      slots: { leading: '<div class="source-filter-tag">example.com</div>' }
+    })
+
+    expect(wrapper.find('.page-subtitle').exists()).toBe(false)
+    expect(wrapper.find('.source-filter-tag').text()).toBe('example.com')
+    expect(wrapper.find('.page-toolbar').classes()).toContain('has-leading')
+  })
+})

--- a/apps/slax-reader-dweb/tests/unit/components/Snapshot/SnapshotArticleSource.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/Snapshot/SnapshotArticleSource.spec.ts
@@ -1,0 +1,43 @@
+import SnapshotArticleSource from '~~/layers/core/app/components/Snapshot/SnapshotArticleSource.vue'
+
+import { mountWithApp } from '~~/tests/setup/mount'
+import { describe, expect, it } from 'vitest'
+
+const mountSource = (props: InstanceType<typeof SnapshotArticleSource>['$props']) => mountWithApp(SnapshotArticleSource, { props })
+
+describe('SnapshotArticleSource', () => {
+  it('uses column, site and domain in priority order', () => {
+    const column = mountSource({ url: 'https://example.com/post', columnName: 'The Column', siteName: 'Example' })
+    const site = mountSource({ url: 'https://example.com/post', siteName: 'Example' })
+    const domain = mountSource({ url: 'https://www.example.com/post' })
+
+    expect(column.find('.article-source-name').text()).toBe('The Column')
+    expect(site.find('.article-source-name').text()).toBe('Example')
+    expect(domain.find('.article-source-name').text()).toBe('example.com')
+  })
+
+  it('renders the parsed author when present and omits its separator otherwise', () => {
+    const withAuthor = mountSource({ url: 'https://example.com/post', siteName: 'Example', author: 'Jane Doe' })
+    const withoutAuthor = mountSource({ url: 'https://example.com/post' })
+
+    expect(withAuthor.find('.article-source-author').text()).toBe('Jane Doe')
+    expect(withAuthor.find('.article-source-separator').text()).toBe('·')
+    expect(withoutAuthor.find('.article-source-author').exists()).toBe(false)
+    expect(withoutAuthor.find('.article-source-separator').exists()).toBe(false)
+  })
+
+  it('normalizes X and gets the author handle from the URL', () => {
+    const wrapper = mountSource({ url: 'https://x.com/jack/status/20', siteName: 'Twitter', author: 'Jack Dorsey' })
+
+    expect(wrapper.find('.article-source-name').text()).toBe('X')
+    expect(wrapper.find('.article-source-author').text()).toBe('@jack')
+  })
+
+  it('links to the original URL and shows the external-link mark', () => {
+    const wrapper = mountSource({ url: 'example.com/post' })
+
+    expect(wrapper.attributes('href')).toBe('https://example.com/post')
+    expect(wrapper.attributes('target')).toBe('_blank')
+    expect(wrapper.find('.article-source-external').text()).toBe('↗')
+  })
+})

--- a/apps/slax-reader-dweb/tests/unit/utils/bookmarkSource.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/utils/bookmarkSource.spec.ts
@@ -1,0 +1,23 @@
+import { bookmarkMatchesSourceDomain, getBookmarkSourceDomain, normalizeSourceDomain } from '~~/layers/core/app/utils/bookmarkSource'
+
+import { describe, expect, it } from 'vitest'
+
+describe('bookmarkSource', () => {
+  it.each([
+    ['Example.COM', 'example.com'],
+    ['https://WWW.Example.com:443/path?q=1', 'www.example.com'],
+    ['sub.example.com.', 'sub.example.com'],
+    ['', '']
+  ])('normalizeSourceDomain(%s) → %s', (input, expected) => {
+    expect(normalizeSourceDomain(input)).toBe(expected)
+  })
+
+  it('host_url 非法时回退 target_url', () => {
+    expect(getBookmarkSourceDomain({ host_url: '://', target_url: 'https://fallback.example/post' })).toBe('fallback.example')
+  })
+
+  it('只匹配相同 hostname', () => {
+    expect(bookmarkMatchesSourceDomain({ host_url: 'https://Example.com/path', target_url: '' }, 'example.com')).toBe(true)
+    expect(bookmarkMatchesSourceDomain({ host_url: 'other.example', target_url: '' }, 'example.com')).toBe(false)
+  })
+})

--- a/apps/slax-reader-extensions/src/components/PanelView.vue
+++ b/apps/slax-reader-extensions/src/components/PanelView.vue
@@ -17,12 +17,12 @@
               <span class="name">Slax Reader</span>
               <span class="version">{{ VERSION }}</span>
             </div>
-            <div class="header-toggle">
-              <span>{{ isAutoToggle ? $t('component.panel.auto_toggle.on') : $t('component.panel.auto_toggle.off') }}</span>
-              <TextTips :tips="isAutoToggle ? $t('component.panel.auto_toggle.enabled_tips') : $t('component.panel.auto_toggle.disabled_tips', [shortcutString])">
+            <TextTips :tips="isAutoToggle ? $t('component.panel.auto_toggle.enabled_tips') : $t('component.panel.auto_toggle.disabled_tips', [shortcutString])">
+              <div class="header-toggle">
+                <span>{{ isAutoToggle ? $t('component.panel.auto_toggle.on') : $t('component.panel.auto_toggle.off') }}</span>
                 <button :class="{ enabled: isAutoToggle }" @click="switchClick"></button>
-              </TextTips>
-            </div>
+              </div>
+            </TextTips>
           </div>
           <div class="sidebar-content">
             <slot name="content" />


### PR DESCRIPTION
## Summary
- Add inbox source-domain filter: click a bookmark's source to filter the list by domain
- Snapshot header renders normalized source with column/author (`SnapshotArticleSource`)
- Add "Open original" action alongside the source filter button
- Fix ChatBot newline behavior: Shift+Enter now uses native browser behavior, Ctrl/Cmd+Enter still inserts manually
- `ListLayoutSwitcher` toolbar now supports a `leading` slot (used to host the source-filter tag)
- Style polish on `SnapshotArticleSource` (pill background, hover state)
- Bump `@nuxt/test-utils` to 4.2.0

## Testing
- Added/updated unit tests: `bookmarkSource.spec.ts`, `SnapshotArticleSource.spec.ts`, `BookmarkCell.spec.ts`, `BookmarkArticle.spec.ts`, `ListLayoutSwitcher.spec.ts`
- `pnpm lint` and `pnpm format:check` pass (via pre-commit hooks on each commit)
