### PR TITLE
实验室：设置页卡片、保存被拦的提示、共用开关组件

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/AddUrlTopModal.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/AddUrlTopModal.vue
@@ -53,6 +53,8 @@
 
 <script setup lang="ts">
 import { RESTMethodPath } from '@commons/types/const'
+import Toast, { ToastType } from '#layers/core/app/components/Toast'
+import { useLabFeatures } from '#layers/core/app/composables/useLabFeatures'
 
 const show = defineModel('show')
 const emits = defineEmits(['addUrlSuccess'])
@@ -60,6 +62,7 @@ const emits = defineEmits(['addUrlSuccess'])
 const addUrlText = ref('')
 const searchModalLoading = ref(false)
 const showError = ref(false)
+const labs = useLabFeatures()
 
 watch(
   () => show.value,
@@ -87,11 +90,22 @@ const topModalClick = async () => {
   }
   const targetUrl = trimmedUrl.value
   searchModalLoading.value = true
-  await request().post<{ bookmark_id: number; status: string }>({
-    url: RESTMethodPath.ADD_URL_BOOKMARK,
-    body: { target_url: targetUrl }
-  })
-  searchModalLoading.value = false
+  try {
+    await request().post<{ bookmark_id: number; status: string }>({
+      url: RESTMethodPath.ADD_URL_BOOKMARK,
+      body: { target_url: targetUrl },
+      // 替换全局的错误 toast：实验室拦截给一个带“去打开”的 toast，其余照旧只显示文案
+      errorInterceptors: err => {
+        if (labs.handleSaveError(err)) return
+        Toast.showToast({ text: err instanceof Error ? err.message : String(err), type: ToastType.Error })
+      }
+    })
+  } catch {
+    // 失败时弹窗留着，用户可以改链接再试
+    return
+  } finally {
+    searchModalLoading.value = false
+  }
   show.value = false
   emits('addUrlSuccess', targetUrl)
   addUrlText.value = ''

--- a/apps/slax-reader-dweb/layers/core/app/components/Modal/ShareModal.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Modal/ShareModal.vue
@@ -12,13 +12,7 @@
             </svg>
             <span>{{ t('component.share_modal.title') }}</span>
           </div>
-          <button class="switch" :class="{ on: isSwitched }" :aria-pressed="isSwitched" @click="switchClick">
-            <span class="knob" :class="{ loading: isSwitchLoading }">
-              <Transition name="opacity">
-                <div class="i-svg-spinners:180-ring-with-bg text-accent text-tag" v-show="isSwitchLoading"></div>
-              </Transition>
-            </span>
-          </button>
+          <SwitchToggle class="switch" :model-value="isSwitched" :loading="isSwitchLoading" @change="switchClick" />
         </div>
         <Transition name="tips">
           <div class="tips" v-show="isShowTips">
@@ -74,6 +68,8 @@ export enum ShareModalType {
 </script>
 
 <script lang="ts" setup>
+import SwitchToggle from '#layers/core/app/components/SwitchToggle.vue'
+
 import { copyText } from '@commons/utils/string'
 
 import { RESTMethodPath } from '@commons/types/const'
@@ -351,30 +347,6 @@ const optionClick = async (index: number) => {
         font-weight: 500;
         color: var(--slax-text);
         line-height: 1.4;
-      }
-    }
-
-    .switch {
-      // 开关关态：弱化文本色淡化底，开态填 accent；遵循 design-system toggle 规范
-      --style: relative flex-none w-36px h-20px rounded-full cursor-pointer transition-colors duration-normal;
-      background: color-mix(in srgb, var(--slax-text-light) 40%, transparent);
-
-      &.on {
-        background: var(--slax-accent);
-      }
-
-      .knob {
-        --style: absolute top-2px left-2px w-16px h-16px rounded-full flex-center transition-all duration-normal;
-        background: var(--slax-surface-solid);
-        box-shadow: var(--slax-shadow-sm);
-
-        &.loading {
-          --style: bg-transparent shadow-none;
-        }
-      }
-
-      &.on .knob {
-        --style: translate-x-16px;
       }
     }
   }

--- a/apps/slax-reader-dweb/layers/core/app/components/SwitchToggle.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/SwitchToggle.vue
@@ -1,0 +1,69 @@
+<template>
+  <button
+    type="button"
+    class="switch-toggle"
+    :class="{ on: modelValue, disabled }"
+    role="switch"
+    :aria-checked="modelValue"
+    :aria-pressed="modelValue"
+    :aria-busy="loading || undefined"
+    :disabled="disabled"
+    @click="onToggle"
+  >
+    <span class="knob" :class="{ loading }">
+      <Transition name="opacity">
+        <div class="i-svg-spinners:180-ring-with-bg text-accent text-tag" v-show="loading"></div>
+      </Transition>
+    </span>
+  </button>
+</template>
+
+<script lang="ts" setup>
+// A native <button> already toggles on Enter and Space; only the click path is handled here.
+const props = defineProps<{
+  modelValue: boolean
+  loading?: boolean
+  disabled?: boolean
+}>()
+
+const emits = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'change', value: boolean): void
+}>()
+
+const onToggle = () => {
+  if (props.disabled || props.loading) return
+  emits('update:modelValue', !props.modelValue)
+  emits('change', !props.modelValue)
+}
+</script>
+
+<style lang="scss" scoped>
+.switch-toggle {
+  // 开关关态：弱化文本色淡化底，开态填 accent；遵循 DESIGN.md toggle 规范
+  --style: relative flex-none w-36px h-20px rounded-full cursor-pointer transition-colors duration-normal p-0 border-none;
+  background: color-mix(in srgb, var(--slax-text-light) 40%, transparent);
+
+  &.on {
+    background: var(--slax-accent);
+  }
+
+  &.disabled {
+    --style: cursor-not-allowed opacity-60;
+  }
+
+  .knob {
+    --style: absolute top-2px left-2px w-16px h-16px rounded-full flex-center transition-all duration-normal;
+    background: var(--slax-surface-solid);
+    box-shadow: var(--slax-shadow-sm);
+
+    &.loading {
+      --style: bg-transparent shadow-none;
+    }
+  }
+
+  &.on .knob {
+    --style: translate-x-16px;
+  }
+}
+</style>

--- a/apps/slax-reader-dweb/layers/core/app/components/Toast/Toast.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Toast/Toast.vue
@@ -1,7 +1,8 @@
 <template>
   <Transition name="toast" @after-leave="onAfterLeave">
-    <div class="text-toast" :class="{ success: type === ToastType.Success, error: type === ToastType.Error }" v-show="showToast">
+    <div class="text-toast" :class="{ success: type === ToastType.Success, error: type === ToastType.Error, 'with-action': !!action }" v-show="showToast">
       <span>{{ text }}</span>
+      <button v-if="action" type="button" class="toast-action" @click="onAction">{{ action.text }}</button>
     </div>
   </Transition>
 </template>
@@ -12,10 +13,15 @@ import { nextTick, onUnmounted, ref } from 'vue'
 import { ToastType } from './type'
 
 const emits = defineEmits(['dismiss'])
-defineProps<{
-  type: ToastType
-  text: string
-}>()
+const props = withDefaults(
+  defineProps<{
+    type: ToastType
+    text: string
+    action?: { text: string; onClick: () => void }
+    duration?: number
+  }>(),
+  { action: undefined, duration: 2500 }
+)
 
 const showToast = ref<boolean>(false)
 nextTick(() => {
@@ -23,8 +29,13 @@ nextTick(() => {
 
   setTimeout(() => {
     showToast.value = false
-  }, 2500)
+  }, props.duration)
 })
+
+const onAction = () => {
+  props.action?.onClick()
+  showToast.value = false
+}
 
 onUnmounted(() => {
   console.log('component dismiss.')
@@ -66,6 +77,31 @@ const onAfterLeave = () => {
     text-overflow: ellipsis;
     white-space: nowrap;
     text-align: center;
+  }
+
+  // 带按钮时文案可以换行，按钮靠右不换行
+  &.with-action {
+    gap: 12px;
+
+    span {
+      width: auto;
+      max-height: none;
+      white-space: normal;
+      text-align: left;
+    }
+  }
+
+  .toast-action {
+    flex: none;
+    padding: 0;
+    border: none;
+    background: none;
+    color: inherit;
+    font: inherit;
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    cursor: pointer;
   }
 }
 

--- a/apps/slax-reader-dweb/layers/core/app/components/Toast/index.ts
+++ b/apps/slax-reader-dweb/layers/core/app/components/Toast/index.ts
@@ -17,7 +17,13 @@ const buildDismissCleanup = (app: ReturnType<typeof createApp>, textToast: HTMLE
   }
 }
 
-const showToast = (options: { text: string; type?: ToastType }) => {
+export interface ToastAction {
+  text: string
+  onClick: () => void
+}
+
+// action: an underlined button after the text (e.g. "Turn on" → settings); duration: ms before auto-dismiss
+const showToast = (options: { text: string; type?: ToastType; action?: ToastAction; duration?: number }) => {
   let toastElement = document.querySelector('.toast.toast-start') as HTMLElement
   if (!toastElement) {
     toastElement = document.createElement('div')
@@ -37,6 +43,8 @@ const showToast = (options: { text: string; type?: ToastType }) => {
   const app = createApp(Toast, {
     text: options.text,
     type: options.type || ToastType.Normal,
+    action: options.action,
+    duration: options.duration,
     onDismiss: () => dismissCleanup?.()
   })
 

--- a/apps/slax-reader-dweb/layers/core/app/components/UserLabSection.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/UserLabSection.vue
@@ -1,0 +1,96 @@
+<template>
+  <section id="labs" class="settings-card lab-section" v-if="rows.length > 0">
+    <div class="title">{{ $t('page.user.labs.title') }}</div>
+    <p class="intro">{{ $t('page.user.labs.intro') }}</p>
+    <div class="lab-list">
+      <div class="lab-row" v-for="row in rows" :key="row.key">
+        <div class="lab-text">
+          <div class="lab-name">
+            <span>{{ $t(`page.user.labs.${row.key}.name`) }}</span>
+            <span class="lab-pill" :class="row.status">{{ $t(row.status === 'graduated' ? 'page.user.labs.status_graduated' : 'page.user.labs.status_active') }}</span>
+          </div>
+          <p class="lab-desc">{{ $t(`page.user.labs.${row.key}.desc`) }}</p>
+        </div>
+        <SwitchToggle :model-value="row.enabled" :disabled="row.status === 'graduated'" :loading="pending === row.key" @change="onToggle(row.key)" />
+      </div>
+    </div>
+  </section>
+</template>
+
+<script lang="ts" setup>
+import SwitchToggle from '#layers/core/app/components/SwitchToggle.vue'
+
+import { useLabFeatures } from '#layers/core/app/composables/useLabFeatures'
+
+const { te } = useI18n()
+const labs = useLabFeatures()
+const pending = ref<string | null>(null)
+
+// 后端可以先于网页挂上一个新功能；没有文案的 key 不显示
+const rows = computed(() => labs.features.value.filter(feature => te(`page.user.labs.${feature.key}.name`)))
+
+onMounted(() => {
+  labs.fetch()
+})
+
+const onToggle = async (key: string) => {
+  if (pending.value) return
+  pending.value = key
+  try {
+    await labs.toggle(key)
+  } finally {
+    pending.value = null
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.settings-card {
+  background: var(--slax-surface);
+  border: 1px solid var(--slax-border);
+  border-radius: var(--slax-radius);
+  box-shadow: inset 0 1px 0 var(--slax-inset-hi);
+  padding: 24px;
+
+  .title {
+    font-family: var(--slax-font-serif);
+    --style: font-600 text-(h2 txt) line-height-33px text-left select-none;
+  }
+
+  .intro {
+    --style: mt-8px text-(card txt-light) line-height-22px;
+  }
+
+  .lab-list {
+    --style: mt-16px flex flex-col;
+  }
+
+  .lab-row {
+    --style: flex items-center justify-between gap-16px py-14px;
+    border-top: 1px solid var(--slax-border);
+  }
+
+  .lab-text {
+    --style: min-w-0 flex-1;
+  }
+
+  .lab-name {
+    --style: flex items-center gap-8px text-(card txt) font-500 line-height-22px;
+  }
+
+  .lab-pill {
+    --style: inline-flex items-center flex-none h-20px px-8px rounded-full text-tag;
+    color: var(--slax-accent);
+    background: var(--slax-accent-bg);
+
+    &.graduated {
+      color: var(--slax-text-light);
+      background: color-mix(in srgb, var(--slax-text-light) 12%, transparent);
+    }
+  }
+
+  .lab-desc {
+    --style: mt-4px text-(tag txt-light) line-height-20px;
+  }
+}
+</style>

--- a/apps/slax-reader-dweb/layers/core/app/composables/useLabFeatures.ts
+++ b/apps/slax-reader-dweb/layers/core/app/composables/useLabFeatures.ts
@@ -1,0 +1,81 @@
+// Labs: per-user switches for features still being tried out.
+// State lives in useState (not the persisted user store) so a stale switch never comes back from localStorage.
+import { RequestError } from '@commons/utils/request'
+
+import { RESTMethodPath } from '@commons/types/const'
+import type { LabFeature } from '@commons/types/interface'
+import Toast, { ToastType } from '#layers/core/app/components/Toast'
+
+export const LAB_FEATURE_DISABLED = 'LAB_FEATURE_DISABLED'
+
+// Mirrors the backend gate: a YouTube video URL (watch / youtu.be / shorts / live / embed with an 11-char id)
+const YOUTUBE_VIDEO_RE = /^https?:\/\/(?:(?:www\.|m\.|music\.)?youtube\.com\/(?:watch\?(?:[^#]*&)?v=|(?:shorts|live|embed)\/)|youtu\.be\/)([A-Za-z0-9_-]{11})(?![A-Za-z0-9_-])/i
+
+// URL → feature key. Only used by clients that write locally without asking the server first.
+const GATED: Array<{ key: string; test: (url: string) => boolean }> = [{ key: 'youtube', test: url => YOUTUBE_VIDEO_RE.test(url) }]
+
+export const gatedFeatureForUrl = (url: string): string | null => GATED.find(g => g.test(url))?.key ?? null
+
+export const useLabFeatures = () => {
+  const features = useState<LabFeature[]>('lab-features', () => [])
+  const loaded = useState<boolean>('lab-features-loaded', () => false)
+
+  const t = (key: string) => useNuxtApp().$i18n.t(key)
+
+  const fetch = async () => {
+    const res = await request().get<{ features: LabFeature[] }>({ url: RESTMethodPath.USER_LABS })
+    features.value = res?.features ?? []
+    loaded.value = true
+  }
+
+  const isEnabled = (key: string) => features.value.some(f => f.key === key && f.enabled)
+
+  // Optimistic: flip first, roll back and toast if the server says no
+  const toggle = async (key: string) => {
+    const feature = features.value.find(f => f.key === key)
+    if (!feature || feature.status === 'graduated') return
+    const next = !feature.enabled
+    feature.enabled = next
+    try {
+      await request().post({
+        url: next ? RESTMethodPath.USER_INFO_ENABLE_SETTING : RESTMethodPath.USER_INFO_DISABLE_SETTING,
+        body: { key: `lab:${key}` }
+      })
+      feature.enabled_at = next ? new Date().toISOString() : null
+    } catch {
+      feature.enabled = !next
+      Toast.showToast({ text: t('common.tips.operate_failed'), type: ToastType.Error })
+    }
+  }
+
+  // true when the URL needs a switch the user has not turned on. Unknown state (not fetched yet) never blocks.
+  const isBlocked = (url: string) => {
+    const key = gatedFeatureForUrl(url)
+    return !!key && loaded.value && !isEnabled(key)
+  }
+
+  const showBlockedToast = (text: string) =>
+    Toast.showToast({
+      text,
+      type: ToastType.Error,
+      duration: 6000,
+      action: { text: t('common.tips.lab_open'), onClick: () => navigateTo('/user#labs') }
+    })
+
+  // Client-side copy for a URL isBlocked() rejected (no server round trip happened)
+  const blockedMessage = (url: string) => {
+    const key = gatedFeatureForUrl(url)
+    return key ? t(`page.user.labs.${key}.blocked`) : ''
+  }
+
+  // For request errorInterceptors: true when the error was the Labs gate and a toast was shown
+  const handleSaveError = (err: unknown): boolean => {
+    if (!(err instanceof RequestError) || err.name !== LAB_FEATURE_DISABLED) return false
+    showBlockedToast(err.message)
+    return true
+  }
+
+  return { features, loaded, fetch, isEnabled, toggle, isBlocked, blockedMessage, showBlockedToast, handleSaveError }
+}
+
+export default useLabFeatures

--- a/apps/slax-reader-dweb/layers/core/app/pages/user.vue
+++ b/apps/slax-reader-dweb/layers/core/app/pages/user.vue
@@ -34,6 +34,9 @@
             </div>
           </div>
 
+          <!-- 实验室（UserLabSection 自带 .settings-card，列表为空时不渲染） -->
+          <UserLabSection />
+
           <!-- 个人信息卡片 -->
           <div class="settings-card">
             <div class="section-title">{{ $t('page.user.personal_info') }}</div>
@@ -77,6 +80,7 @@ import AILanguageTips from '#layers/core/app/components/Tips/AILanguageTips.vue'
 import UserDeleteAccountSection from '#layers/core/app/components/UserDeleteAccountSection.vue'
 import UserExportSection from '#layers/core/app/components/UserExportSection.vue'
 import UserImportSection from '#layers/core/app/components/UserImportSection.vue'
+import UserLabSection from '#layers/core/app/components/UserLabSection.vue'
 import UserPageSkeleton from '#layers/core/app/components/UserPageSkeleton.vue'
 
 import { getPreferredLanguage, isSlaxReaderApp } from '../utils/environment'

--- a/apps/slax-reader-dweb/layers/core/i18n/locales/en.json
+++ b/apps/slax-reader-dweb/layers/core/i18n/locales/en.json
@@ -156,7 +156,8 @@
       "trash_success": "Bookmark moved to trash",
       "unarchive_success": "Content has been Unarchive",
       "unstar_success": "Content has been unstarred",
-      "unsubscribe_success": "Unsubscribe successful!"
+      "unsubscribe_success": "Unsubscribe successful!",
+      "lab_open": "Turn on"
     }
   },
   "component": {
@@ -904,7 +905,18 @@
       "update_share_status_failed": "Failed to update sharing status",
       "update_stripe_info": "Update Stripe info",
       "url_count": "URL Count",
-      "view_import_progress": "View import progress"
+      "view_import_progress": "View import progress",
+      "labs": {
+        "title": "Labs",
+        "intro": "These features are still rough. They may have bugs and may be removed at any time. If something breaks after you turn one on, tell us in the Telegram group.",
+        "status_active": "In Labs",
+        "status_graduated": "Released",
+        "youtube": {
+          "name": "YouTube videos",
+          "desc": "Save a YouTube link and read along with its transcript. English captions are preferred for now, and the app does not follow the transcript yet.",
+          "blocked": "YouTube videos are still in Labs. Turn it on in Settings, then save again"
+        }
+      }
     }
   },
   "util": {

--- a/apps/slax-reader-dweb/layers/core/i18n/locales/zh.json
+++ b/apps/slax-reader-dweb/layers/core/i18n/locales/zh.json
@@ -156,7 +156,8 @@
       "trash_success": "内容已移除",
       "unarchive_success": "内容已取消归档",
       "unstar_success": "内容已取消加星",
-      "unsubscribe_success": "取消订阅成功!"
+      "unsubscribe_success": "取消订阅成功!",
+      "lab_open": "去打开"
     }
   },
   "component": {
@@ -905,7 +906,18 @@
       "update_share_status_failed": "更新分享状态失败",
       "update_stripe_info": "更新 Stripe 信息",
       "url_count": "URL Count",
-      "view_import_progress": "查看导入进度"
+      "view_import_progress": "查看导入进度",
+      "labs": {
+        "title": "实验室",
+        "intro": "这里的功能还在打磨，可能有 bug，也可能随时下线。打开后遇到问题，欢迎到 Telegram 群告诉我们。",
+        "status_active": "实验中",
+        "status_graduated": "已正式发布",
+        "youtube": {
+          "name": "YouTube 视频",
+          "desc": "保存 YouTube 链接，自动拉取字幕，边看边读。目前英文字幕优先，App 端不支持字幕跟随",
+          "blocked": "YouTube 视频还在实验室里，请到设置页打开后再保存"
+        }
+      }
     }
   },
   "util": {

--- a/apps/slax-reader-dweb/tests/unit/components/BookmarkList/AddUrlTopModal.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/BookmarkList/AddUrlTopModal.spec.ts
@@ -9,20 +9,46 @@ import { nextTick } from 'vue'
 
 import AddUrlTopModal from '~~/layers/core/app/components/BookmarkList/AddUrlTopModal.vue'
 
+import { RequestError } from '@commons/utils/request'
+
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
 import { mountWithApp } from '~~/tests/setup/mount'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockRequest, mockPost } = vi.hoisted(() => {
+const { mockRequest, mockPost, mockToastShowToast, mockNavigateTo } = vi.hoisted(() => {
   const mockPost = vi.fn(() => Promise.resolve({ bookmark_id: 1, status: 'ok' }))
   return {
     mockPost,
-    mockRequest: vi.fn(() => ({ post: mockPost }))
+    mockRequest: vi.fn(() => ({ post: mockPost })),
+    mockToastShowToast: vi.fn(),
+    mockNavigateTo: vi.fn()
   }
 })
 
 mockNuxtImport('request', () => mockRequest)
+mockNuxtImport('navigateTo', () => mockNavigateTo)
+
+vi.mock('#layers/core/app/components/Toast', () => ({
+  default: { showToast: mockToastShowToast },
+  ToastType: { Success: 'success', Error: 'error', Normal: 'normal' }
+}))
+
+// 模拟 request()：真实实现会先调 per-request errorInterceptors 再 reject
+const rejectWith = (err: Error) =>
+  (mockPost as ReturnType<typeof vi.fn>).mockImplementationOnce(async (options: { errorInterceptors?: (e: unknown) => void }) => {
+    options.errorInterceptors?.(err)
+    throw err
+  })
+
+const submitUrl = async (url: string) => {
+  const input = document.querySelector('.modal-input') as HTMLInputElement
+  input.value = url
+  input.dispatchEvent(new Event('input'))
+  await nextTick()
+  ;(document.querySelector('.modal-btn-primary') as HTMLButtonElement).click()
+  await flushPromises()
+}
 
 // Teleport 渲染到 body，需要 attachTo 才能在 document 中找到元素
 const mountModal = (show: boolean) =>
@@ -112,6 +138,35 @@ describe('AddUrlTopModal', () => {
     expect(wrapper.emitted('addUrlSuccess')).toBeTruthy()
     expect(wrapper.emitted('addUrlSuccess')![0]).toEqual(['https://example.com'])
     expect(wrapper.emitted('update:show')).toBeTruthy()
+  })
+
+  it('实验室拦截（LAB_FEATURE_DISABLED）→ toast 带“去打开”，弹窗留着，loading 复位', async () => {
+    const wrapper = mountModal(true)
+    await nextTick()
+    rejectWith(new RequestError({ message: 'YouTube videos are still in Labs', name: 'LAB_FEATURE_DISABLED', code: 400 }))
+    await submitUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+
+    expect(mockToastShowToast).toHaveBeenCalledTimes(1)
+    const options = mockToastShowToast.mock.calls[0]![0]
+    expect(options).toMatchObject({ text: 'YouTube videos are still in Labs', type: 'error', duration: 6000, action: { text: 'Turn on' } })
+    options.action.onClick()
+    expect(mockNavigateTo).toHaveBeenCalledWith('/user#labs')
+
+    expect(wrapper.emitted('addUrlSuccess')).toBeFalsy()
+    expect(wrapper.emitted('update:show')).toBeFalsy()
+    expect(document.querySelector('.modal-dialog')).not.toBeNull()
+    expect(document.querySelector('.modal-btn-primary .i-svg-spinners\\:90-ring')).toBeNull()
+  })
+
+  it('其它错误 → 只显示服务端文案，没有按钮，弹窗留着', async () => {
+    const wrapper = mountModal(true)
+    await nextTick()
+    rejectWith(new RequestError({ message: 'Blocked target url', name: 'BLOCK_TARGET_URL', code: 400 }))
+    await submitUrl('https://example.com/blocked')
+
+    expect(mockToastShowToast).toHaveBeenCalledWith({ text: 'Blocked target url', type: 'error' })
+    expect(wrapper.emitted('addUrlSuccess')).toBeFalsy()
+    expect(document.querySelector('.modal-dialog')).not.toBeNull()
   })
 
   it('show false→true 切换 → 不抛错（watch focus 覆盖）', async () => {

--- a/apps/slax-reader-dweb/tests/unit/components/SwitchToggle.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/SwitchToggle.spec.ts
@@ -1,0 +1,47 @@
+// SwitchToggle 组件单测
+// props: modelValue / loading / disabled；emit: update:modelValue + change
+// 原生 button 已支持 Enter / Space 触发 click，这里只测 click 路径
+import SwitchToggle from '~~/layers/core/app/components/SwitchToggle.vue'
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+describe('SwitchToggle', () => {
+  it('关态：无 on class，aria-checked=false', () => {
+    const wrapper = mount(SwitchToggle, { props: { modelValue: false } })
+    const button = wrapper.find('button.switch-toggle')
+    expect(button.classes()).not.toContain('on')
+    expect(button.attributes('role')).toBe('switch')
+    expect(button.attributes('aria-checked')).toBe('false')
+    expect(button.attributes('type')).toBe('button')
+  })
+
+  it('开态：on class + aria-checked=true', () => {
+    const wrapper = mount(SwitchToggle, { props: { modelValue: true } })
+    expect(wrapper.find('button').classes()).toContain('on')
+    expect(wrapper.find('button').attributes('aria-checked')).toBe('true')
+  })
+
+  it('click → emit update:modelValue 和 change，值取反', async () => {
+    const wrapper = mount(SwitchToggle, { props: { modelValue: false } })
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('update:modelValue')).toEqual([[true]])
+    expect(wrapper.emitted('change')).toEqual([[true]])
+  })
+
+  it('disabled → 有 disabled 属性，click 不 emit', async () => {
+    const wrapper = mount(SwitchToggle, { props: { modelValue: true, disabled: true } })
+    expect(wrapper.find('button').attributes('disabled')).toBeDefined()
+    expect(wrapper.find('button').classes()).toContain('disabled')
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('change')).toBeUndefined()
+  })
+
+  it('loading → knob 带 loading class，aria-busy，click 不 emit', async () => {
+    const wrapper = mount(SwitchToggle, { props: { modelValue: false, loading: true } })
+    expect(wrapper.find('.knob').classes()).toContain('loading')
+    expect(wrapper.find('button').attributes('aria-busy')).toBe('true')
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('change')).toBeUndefined()
+  })
+})

--- a/apps/slax-reader-dweb/tests/unit/components/Toast/index.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/Toast/index.spec.ts
@@ -38,6 +38,37 @@ describe('Toast/index showToast 工厂', () => {
     expect(container.style.getPropertyValue('z-index')).toBe('9999')
   })
 
+  it('options.action → 渲染下划线按钮，点击后执行 onClick 并关闭', async () => {
+    vi.useFakeTimers()
+    const onClick = vi.fn()
+    ToastModule.showToast({ text: 'Blocked', type: ToastType.Error, action: { text: 'Turn on', onClick } })
+    await vi.advanceTimersByTimeAsync(0)
+    const button = document.querySelector('.text-toast .toast-action') as HTMLButtonElement
+    expect(button).not.toBeNull()
+    expect(button.textContent).toBe('Turn on')
+    const toast = document.querySelector('.text-toast') as HTMLElement
+    expect(toast.classList.contains('with-action')).toBe(true)
+    expect(toast.style.display).not.toBe('none')
+    button.click()
+    // v-show 在 Transition leave 结束后才写 display:none，happy-dom 下靠 fake timers 推一帧
+    await vi.advanceTimersByTimeAsync(50)
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(toast.style.display).toBe('none')
+    vi.useRealTimers()
+  })
+
+  it('options.duration 覆盖默认 2500ms', async () => {
+    vi.useFakeTimers()
+    ToastModule.showToast({ text: 'Long', duration: 6000 })
+    await vi.advanceTimersByTimeAsync(0)
+    const toast = document.querySelector('.text-toast') as HTMLElement
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(toast.style.display).not.toBe('none')
+    await vi.advanceTimersByTimeAsync(3100)
+    expect(toast.style.display).toBe('none')
+    vi.useRealTimers()
+  })
+
   it('options.type 透传到 Toast 组件 props', () => {
     ToastModule.showToast({ text: 'Err', type: ToastType.Error })
     const errorToast = document.querySelector('.text-toast.error')

--- a/apps/slax-reader-dweb/tests/unit/components/UserLabSection.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/UserLabSection.spec.ts
@@ -1,0 +1,109 @@
+// UserLabSection 组件单测
+// 挂载时 GET /v1/user/labs；空列表不渲染整张卡；没有文案的 key 跳过；
+// graduated 行开关禁用且显示为开；点击开关 → POST setting/enable|disable，失败回滚 + toast
+import UserLabSection from '~~/layers/core/app/components/UserLabSection.vue'
+
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { flushPromises } from '@vue/test-utils'
+import { mountWithApp } from '~~/tests/setup/mount'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGet, mockPost, mockRequest, mockToastShowToast } = vi.hoisted(() => {
+  const mockGet = vi.fn()
+  const mockPost = vi.fn()
+  return {
+    mockGet,
+    mockPost,
+    mockRequest: vi.fn(() => ({ get: mockGet, post: mockPost })),
+    mockToastShowToast: vi.fn()
+  }
+})
+
+mockNuxtImport('request', () => mockRequest)
+
+vi.mock('#layers/core/app/components/Toast', () => ({
+  default: { showToast: mockToastShowToast },
+  ToastType: { Success: 'success', Error: 'error', Normal: 'normal' }
+}))
+
+// 工厂而不是常量：组件会通过响应式代理改到原对象，常量会把上一个用例的开关状态带进下一个
+const youtube = () => ({ key: 'youtube', status: 'active', enabled: false, enabled_at: null })
+
+const mountSection = async (features: unknown[]) => {
+  mockGet.mockResolvedValue({ features })
+  const wrapper = mountWithApp(UserLabSection)
+  await flushPromises()
+  return wrapper
+}
+
+describe('UserLabSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPost.mockResolvedValue('ok')
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('挂载时请求 /v1/user/labs', async () => {
+    await mountSection([])
+    expect(mockGet).toHaveBeenCalledWith({ url: '/v1/user/labs' })
+  })
+
+  it('列表为空 → 整张卡不渲染', async () => {
+    const wrapper = await mountSection([])
+    expect(wrapper.find('.settings-card').exists()).toBe(false)
+  })
+
+  it('渲染标题、说明和功能行；没有文案的 key 跳过', async () => {
+    const wrapper = await mountSection([youtube(), { key: 'no_such_feature', status: 'active', enabled: true, enabled_at: null }])
+    expect(wrapper.find('#labs.settings-card').exists()).toBe(true)
+    expect(wrapper.find('.title').text()).toBe('Labs')
+    expect(wrapper.find('.intro').text()).toContain('still rough')
+    const rows = wrapper.findAll('.lab-row')
+    expect(rows.length).toBe(1)
+    expect(rows[0]!.find('.lab-name span').text()).toBe('YouTube videos')
+    expect(rows[0]!.find('.lab-pill').text()).toBe('In Labs')
+    expect(rows[0]!.find('.lab-desc').text()).toContain('transcript')
+    expect(rows[0]!.find('.switch-toggle').classes()).not.toContain('on')
+  })
+
+  it('graduated → 标签“已正式发布”，开关禁用并显示为开', async () => {
+    const wrapper = await mountSection([{ ...youtube(), status: 'graduated', enabled: true }])
+    const row = wrapper.find('.lab-row')
+    expect(row.find('.lab-pill').text()).toBe('Released')
+    const toggle = row.find('.switch-toggle')
+    expect(toggle.classes()).toContain('on')
+    expect(toggle.attributes('disabled')).toBeDefined()
+    await toggle.trigger('click')
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it('点击开关 → 乐观置开 + POST /v1/user/setting/enable { key: lab:youtube }', async () => {
+    const wrapper = await mountSection([youtube()])
+    await wrapper.find('.switch-toggle').trigger('click')
+    expect(wrapper.find('.switch-toggle').classes()).toContain('on')
+    await flushPromises()
+    expect(mockPost).toHaveBeenCalledWith({ url: '/v1/user/setting/enable', body: { key: 'lab:youtube' } })
+    expect(wrapper.find('.switch-toggle').classes()).toContain('on')
+  })
+
+  it('已开的功能点击 → POST /v1/user/setting/disable', async () => {
+    const wrapper = await mountSection([{ ...youtube(), enabled: true, enabled_at: '2026-09-08T00:00:00.000Z' }])
+    await wrapper.find('.switch-toggle').trigger('click')
+    await flushPromises()
+    expect(mockPost).toHaveBeenCalledWith({ url: '/v1/user/setting/disable', body: { key: 'lab:youtube' } })
+    expect(wrapper.find('.switch-toggle').classes()).not.toContain('on')
+  })
+
+  it('请求失败 → 回滚开关 + toast operate_failed', async () => {
+    mockPost.mockRejectedValue(new Error('500'))
+    const wrapper = await mountSection([youtube()])
+    await wrapper.find('.switch-toggle').trigger('click')
+    await flushPromises()
+    expect(mockToastShowToast).toHaveBeenCalledWith(expect.objectContaining({ text: 'Operation failed', type: 'error' }))
+    expect(mockPost).toHaveBeenCalledTimes(1)
+    expect(wrapper.find('.switch-toggle').classes()).not.toContain('on')
+  })
+})

--- a/apps/slax-reader-dweb/tests/unit/composables/useLabFeatures.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/composables/useLabFeatures.spec.ts
@@ -1,0 +1,159 @@
+// useLabFeatures 组合函数单测
+// fetch → useState；toggle 乐观切换 + 失败回滚；isBlocked 只在拉过列表后才拦；
+// handleSaveError 只认 LAB_FEATURE_DISABLED，弹带“去打开”的 toast
+import { RequestError } from '@commons/utils/request'
+
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { useLabFeatures } from '~~/layers/core/app/composables/useLabFeatures'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGet, mockPost, mockRequest, mockToastShowToast, mockNavigateTo } = vi.hoisted(() => {
+  const mockGet = vi.fn()
+  const mockPost = vi.fn()
+  return {
+    mockGet,
+    mockPost,
+    mockRequest: vi.fn(() => ({ get: mockGet, post: mockPost })),
+    mockToastShowToast: vi.fn(),
+    mockNavigateTo: vi.fn()
+  }
+})
+
+mockNuxtImport('request', () => mockRequest)
+mockNuxtImport('navigateTo', () => mockNavigateTo)
+
+vi.mock('#layers/core/app/components/Toast', () => ({
+  default: { showToast: mockToastShowToast },
+  ToastType: { Success: 'success', Error: 'error', Normal: 'normal' }
+}))
+
+const youtube = () => ({ key: 'youtube', status: 'active' as const, enabled: false, enabled_at: null })
+
+describe('useLabFeatures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPost.mockResolvedValue('ok')
+    // useState 在同一个 nuxt app 里跨用例共享，每个用例先清掉
+    const labs = useLabFeatures()
+    labs.features.value = []
+    labs.loaded.value = false
+  })
+
+  describe('fetch', () => {
+    it('GET /v1/user/labs → features + loaded', async () => {
+      mockGet.mockResolvedValue({ features: [youtube()] })
+      const labs = useLabFeatures()
+      await labs.fetch()
+      expect(mockGet).toHaveBeenCalledWith({ url: '/v1/user/labs' })
+      expect(labs.features.value).toEqual([youtube()])
+      expect(labs.loaded.value).toBe(true)
+    })
+
+    it('返回空 body → 空列表', async () => {
+      mockGet.mockResolvedValue(undefined)
+      const labs = useLabFeatures()
+      await labs.fetch()
+      expect(labs.features.value).toEqual([])
+    })
+  })
+
+  describe('toggle', () => {
+    it('关 → 开：先改本地再 POST enable，成功后写 enabled_at', async () => {
+      const labs = useLabFeatures()
+      labs.features.value = [youtube()]
+      const pending = labs.toggle('youtube')
+      expect(labs.isEnabled('youtube')).toBe(true)
+      await pending
+      expect(mockPost).toHaveBeenCalledWith({ url: '/v1/user/setting/enable', body: { key: 'lab:youtube' } })
+      expect(labs.features.value[0]!.enabled_at).toMatch(/^\d{4}-/)
+    })
+
+    it('开 → 关：POST disable，enabled_at 清空', async () => {
+      const labs = useLabFeatures()
+      labs.features.value = [{ ...youtube(), enabled: true, enabled_at: '2026-09-08T00:00:00.000Z' }]
+      await labs.toggle('youtube')
+      expect(mockPost).toHaveBeenCalledWith({ url: '/v1/user/setting/disable', body: { key: 'lab:youtube' } })
+      expect(labs.features.value[0]!).toMatchObject({ enabled: false, enabled_at: null })
+    })
+
+    it('失败 → 回滚 + toast', async () => {
+      mockPost.mockRejectedValue(new Error('500'))
+      const labs = useLabFeatures()
+      labs.features.value = [youtube()]
+      await labs.toggle('youtube')
+      expect(labs.isEnabled('youtube')).toBe(false)
+      expect(mockToastShowToast).toHaveBeenCalledWith({ text: 'Operation failed', type: 'error' })
+    })
+
+    it('graduated 和未知 key 不发请求', async () => {
+      const labs = useLabFeatures()
+      labs.features.value = [{ ...youtube(), status: 'graduated', enabled: true }]
+      await labs.toggle('youtube')
+      await labs.toggle('nope')
+      expect(mockPost).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isBlocked', () => {
+    const videoUrls = [
+      'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      'https://youtube.com/watch?feature=share&v=dQw4w9WgXcQ',
+      'https://youtu.be/dQw4w9WgXcQ?t=10',
+      'https://m.youtube.com/shorts/dQw4w9WgXcQ',
+      'https://www.youtube.com/live/dQw4w9WgXcQ',
+      'https://www.youtube.com/embed/dQw4w9WgXcQ'
+    ]
+
+    it('没拉过列表 → 不拦', () => {
+      const labs = useLabFeatures()
+      expect(labs.isBlocked(videoUrls[0]!)).toBe(false)
+    })
+
+    it.each(videoUrls)('youtube 关着 → 拦 %s', url => {
+      const labs = useLabFeatures()
+      labs.features.value = [youtube()]
+      labs.loaded.value = true
+      expect(labs.isBlocked(url)).toBe(true)
+    })
+
+    it('youtube 开着 → 放行', () => {
+      const labs = useLabFeatures()
+      labs.features.value = [{ ...youtube(), enabled: true }]
+      labs.loaded.value = true
+      expect(labs.isBlocked(videoUrls[0]!)).toBe(false)
+    })
+
+    it.each(['https://example.com/post', 'https://www.youtube.com/@channel', 'https://www.youtube.com/playlist?list=PL123', 'not a url'])('非视频链接不拦 %s', url => {
+      const labs = useLabFeatures()
+      labs.features.value = [youtube()]
+      labs.loaded.value = true
+      expect(labs.isBlocked(url)).toBe(false)
+    })
+
+    it('blockedMessage 给出客户端文案', () => {
+      const labs = useLabFeatures()
+      expect(labs.blockedMessage(videoUrls[0]!)).toBe('YouTube videos are still in Labs. Turn it on in Settings, then save again')
+      expect(labs.blockedMessage('https://example.com')).toBe('')
+    })
+  })
+
+  describe('handleSaveError', () => {
+    it('LAB_FEATURE_DISABLED → toast 带“去打开”，点击跳设置页', () => {
+      const labs = useLabFeatures()
+      const err = new RequestError({ message: 'YouTube videos are still in Labs', name: 'LAB_FEATURE_DISABLED', code: 400 })
+      expect(labs.handleSaveError(err)).toBe(true)
+      expect(mockToastShowToast).toHaveBeenCalledTimes(1)
+      const options = mockToastShowToast.mock.calls[0]![0]
+      expect(options).toMatchObject({ text: 'YouTube videos are still in Labs', type: 'error', duration: 6000, action: { text: 'Turn on' } })
+      options.action.onClick()
+      expect(mockNavigateTo).toHaveBeenCalledWith('/user#labs')
+    })
+
+    it('其它错误 → false，不弹', () => {
+      const labs = useLabFeatures()
+      expect(labs.handleSaveError(new RequestError({ message: 'x', name: 'ERROR_PARAM', code: 400 }))).toBe(false)
+      expect(labs.handleSaveError(new Error('x'))).toBe(false)
+      expect(mockToastShowToast).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/slax-reader-dweb/tests/unit/pages/user.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/pages/user.spec.ts
@@ -1,5 +1,5 @@
 // pages/user.vue 单测
-// 覆盖：加载态骨架屏 / 内容态卡片结构 / 返回按钮 / error_alert query 处理
+// 覆盖：加载态骨架屏 / 内容态卡片结构 / 实验室卡片按 /labs 返回显隐 / 返回按钮 / error_alert query 处理
 import UserRelatedInfoSection from '~~/layers/core/app/components/global/UserRelatedInfoSection.vue'
 import UserImportSection from '~~/layers/core/app/components/UserImportSection.vue'
 import UserPage from '~~/layers/core/app/pages/user.vue'
@@ -20,7 +20,7 @@ const { mockRoute, mockNavigateTo, mockRequest, mockGet, mockAnalyticsLog, mockT
     mockGet,
     mockAnalyticsLog: vi.fn(),
     mockToastShowToast: vi.fn(),
-    mockUseI18n: vi.fn(() => ({ locale: { value: 'en' }, t: mockT }))
+    mockUseI18n: vi.fn(() => ({ locale: { value: 'en' }, t: mockT, te: () => true }))
   }
 })
 
@@ -50,13 +50,18 @@ const baseUserDetail = {
   ai_lang: 'en'
 }
 
+// request().get 按 url 分发：/v1/user/labs 默认返回空列表，其余返回用户详情
+let labFeatures: unknown[] = []
+const dispatchGet = ({ url }: { url: string }) => Promise.resolve(url === '/v1/user/labs' ? { features: labFeatures } : baseUserDetail)
+
 beforeEach(() => {
   mockRoute.query = {}
   mockNavigateTo.mockClear()
   mockGet.mockReset()
   mockAnalyticsLog.mockClear()
   mockToastShowToast.mockClear()
-  mockGet.mockResolvedValue(baseUserDetail)
+  labFeatures = []
+  mockGet.mockImplementation(dispatchGet)
 })
 
 afterEach(() => {
@@ -74,6 +79,10 @@ const stubs = {
   UserImportSection: {
     name: 'UserImportSection',
     template: '<section class="settings-card user-import-stub"></section>'
+  },
+  UserExportSection: {
+    name: 'UserExportSection',
+    template: '<section class="settings-card user-export-stub"></section>'
   },
   UserDeleteAccountSection: {
     name: 'UserDeleteAccountSection',
@@ -115,10 +124,21 @@ describe('pages/user', () => {
       expect(wrapper.find('.user-topbar').exists()).toBe(true)
     })
 
-    it('渲染 5 个 .settings-card（语言 + 个人信息 + 第三方绑定 + 导入 + 帮助支持）', async () => {
+    it('渲染 6 个 .settings-card（语言 + 个人信息 + 第三方绑定 + 导入 + 导出 + 帮助支持），实验室为空时不占卡', async () => {
       const wrapper = mountWithApp(UserPage, { global: { stubs } })
       await flushPromises()
-      expect(wrapper.findAll('.settings-card').length).toBe(5)
+      expect(wrapper.findAll('.settings-card').length).toBe(6)
+      expect(wrapper.find('#labs').exists()).toBe(false)
+    })
+
+    it('/labs 返回一个功能 → 第 7 张卡是实验室，放在语言卡片后面', async () => {
+      labFeatures = [{ key: 'youtube', status: 'active', enabled: false, enabled_at: null }]
+      const wrapper = mountWithApp(UserPage, { global: { stubs } })
+      await flushPromises()
+      const cards = wrapper.findAll('.settings-card')
+      expect(cards.length).toBe(7)
+      expect(cards[1]!.attributes('id')).toBe('labs')
+      expect(mockGet).toHaveBeenCalledWith(expect.objectContaining({ url: '/v1/user/labs' }))
     })
 
     it('UserRelatedInfoSection 和 UserImportSection 组件存在', async () => {

--- a/apps/slax-reader-extensions/src/components/Collect.vue
+++ b/apps/slax-reader-extensions/src/components/Collect.vue
@@ -14,6 +14,7 @@
       <div class="title">
         <span class="">{{ title }}</span>
       </div>
+      <a v-if="labBlocked" class="lab-link" :href="labsUrl" target="_blank" rel="noopener">{{ t('open_labs_in_settings') }}</a>
       <div class="content" v-show="!isLoading">
         <div class="slax-buttons collected" v-if="bookmarkId > 0 && false">
           <button class="source" @click="checkSource">{{ t('click_to_view') }}</button>
@@ -54,6 +55,10 @@ const showPopup = ref(false)
 const bookmarkExists = ref(false)
 const title = ref('')
 const isUrlBlocked = ref(false)
+// Labs gate: the server copy goes in the status line, this adds a link to the web settings
+const labBlocked = ref(false)
+const labsUrl = `${process.env.PUBLIC_BASE_URL}/user#labs`
+let keepPopupOpen = false
 const bookmarkId = ref(0)
 const isLoading = computed(() => {
   return loading.value
@@ -90,6 +95,7 @@ const t = (
     | 'collection_not_supported'
     | 'recollection'
     | 'not_collected'
+    | 'open_labs_in_settings'
     | 'click_to_view'
     | 'removal'
     | 'removal_successful'
@@ -169,6 +175,8 @@ const updateTitle = () => {
 }
 
 const addBookmark = async () => {
+  labBlocked.value = false
+  keepPopupOpen = false
   showLoading(i18n.t('collection_in_progress'))
   try {
     const resp = await request.post<AddBookmarkResp>({
@@ -199,13 +207,22 @@ const addBookmark = async () => {
         hideLoading()
         return
       }
+      if (error.name === 'LAB_FEATURE_DISABLED') {
+        labBlocked.value = true
+        keepPopupOpen = true
+        showTips(error.message)
+        return
+      }
     }
 
     showTips(i18n.t('collection_failed'))
   } finally {
-    setTimeout(() => {
-      closePopup()
-    }, 2000)
+    // 实验室拦截时留着弹窗，用户要点链接去打开
+    if (!keepPopupOpen) {
+      setTimeout(() => {
+        closePopup()
+      }, 2000)
+    }
   }
 }
 
@@ -299,6 +316,10 @@ const closePopup = () => {
         --style: w-full h-full;
       }
     }
+  }
+
+  .lab-link {
+    --style: block mt-2 text-13px underline cursor-pointer text-#16b998;
   }
 
   .title {

--- a/apps/slax-reader-extensions/src/components/SidePanel.vue
+++ b/apps/slax-reader-extensions/src/components/SidePanel.vue
@@ -113,6 +113,8 @@ import {
 } from './Selection/adapters'
 import { ExtensionsArticleSelection } from './Selection/ExtensionsArticleSelection'
 import { MarkModal } from './Selection/modal'
+import Toast from './Toast'
+import { ToastType } from './Toast/type'
 import { RESTMethodPath } from '@commons/types/const'
 import { type AddBookmarkReq, type AddBookmarkResp, type BookmarkBriefDetail, MarkType as BackendMarkType, type UserInfo } from '@commons/types/interface'
 import type { MarkCommentInfo, MarkItemInfo, QuoteData } from '@slax-reader/selection/types'
@@ -689,6 +691,13 @@ const addBookmark = async () => {
       bookmarkUrl.value = body.target_url
       isCollected.value = true
     }
+  } catch (error) {
+    // Labs gate: the server copy already says to turn it on in Settings
+    if (error instanceof RequestError && error.name === 'LAB_FEATURE_DISABLED') {
+      Toast.showToast({ text: error.message, type: ToastType.Error })
+      return
+    }
+    throw error
   } finally {
     isLoading.value = false
   }

--- a/apps/slax-reader-extensions/src/locales/en.json
+++ b/apps/slax-reader-extensions/src/locales/en.json
@@ -155,5 +155,6 @@
       "search_bookmark_finished": "Knowledge base search complete",
       "search_finished": "Search complete"
     }
-  }
+  },
+  "open_labs_in_settings": "Turn on in web settings ↗"
 }

--- a/apps/slax-reader-extensions/src/locales/zh_CN.json
+++ b/apps/slax-reader-extensions/src/locales/zh_CN.json
@@ -155,5 +155,6 @@
       "search_bookmark_finished": "资料库搜索完成",
       "search_finished": "搜索完成"
     }
-  }
+  },
+  "open_labs_in_settings": "去网页设置打开 ↗"
 }

--- a/commons/types/src/const.ts
+++ b/commons/types/src/const.ts
@@ -35,6 +35,7 @@ enum RESTMethodPath {
   TOKEN_REFRESH = '/v1/user/refresh',
   USER_INFO_ENABLE_SETTING = '/v1/user/setting/enable',
   USER_INFO_DISABLE_SETTING = '/v1/user/setting/disable',
+  USER_LABS = '/v1/user/labs',
   DELETE_MY_ACCOUNT = '/v1/user/delete_my_account',
   ADD_MARK = '/v1/mark/create',
   DELETE_MARK = '/v1/mark/delete',

--- a/commons/types/src/interface.ts
+++ b/commons/types/src/interface.ts
@@ -381,6 +381,14 @@ export interface UserDetailInfo {
   ai_lang: string
 }
 
+/** One row of the Labs card; retired features never come back from the server */
+export interface LabFeature {
+  key: string
+  status: 'active' | 'graduated'
+  enabled: boolean
+  enabled_at: string | null
+}
+
 export interface UserShareCollectInfo {
   show_name: string
   price: number


### PR DESCRIPTION
设置页语言卡片下面加一张“实验室”卡：每个实验功能一行，名字、状态标签、一句说明、开关。列表为空时整张卡不渲染，自托管看不到变化。开关状态从 `GET /v1/user/labs` 拉，写开关走现有的 `POST /v1/user/setting/enable|disable`，key 是 `lab:<功能>`。

- `UserLabSection.vue`：卡片。没有文案的 key 跳过，后端可以先于网页挂新功能。已毕业的行开关禁用并显示为开。
- `useLabFeatures`：状态放 `useState`，不进持久化的 user store。乐观切换，失败回滚并 toast。`isBlocked(url)` 用和后端一样的 YouTube 视频正则，给本地写入的客户端预检；没拉过列表时不拦。`handleSaveError()` 给请求的 `errorInterceptors` 用。
- `SwitchToggle.vue`：从分享弹窗抽出来的开关，分享弹窗改用它。
- Toast 支持一个按钮和自定义时长。
- 添加链接弹窗：`LAB_FEATURE_DISABLED` 时弹服务端文案加“去打开”按钮，跳 `/user#labs`；其它错误显示文案。弹窗留着，loading 复位（以前任何错误都会卡住）。
- 浏览器扩展：收藏弹窗被拦时显示服务端文案和一个“去网页设置打开”的链接，不自动关；侧边栏用 toast。
- zh / en 文案，`USER_LABS` 常量和 `LabFeature` 类型。
- 测试：卡片、组合函数、开关、Toast 按钮、弹窗两个错误分支。`user.spec` 原来断言 5 张卡但实际渲染 6 张（导出卡加了没改测试），改成 6，加了一条实验室卡的用例。

验证：vitest 全套 1410 条通过，只有 `tests/unit/utils/modal.spec.ts` 挂，基线上它就挂；`vue-tsc` 错误数 21，和基线一样；扩展 `vue-tsc` 65，和基线一样；`nuxt build` 通过。改过的文件 eslint 和 prettier 通过。

基于 #277（导出）的分支，那个合并后这个会自动改成对 main。要配合后端的实验室 PR 一起发，后端先发。

关联 PR：

- 共享 API：https://github.com/slax-lab/slax-reader-api/pull/117
- 托管后端：https://github.com/unnoo/slax_reader_backend/pull/832
- 共享网页：https://github.com/slax-lab/slax-reader-web/pull/278
- 托管前端：https://github.com/unnoo/slax_reader_frontend/pull/1551
- App：https://github.com/slax-lab/slax-reader-client/pull/128
- 数据日报：https://github.com/wulujia/slax-reader-data-bot/pull/1