### PR TITLE
🔧 Re-enable redirect to /onboarding

### DIFF
--- a/.codex/skills/review-slax-web/references/search-triggers.md
+++ b/.codex/skills/review-slax-web/references/search-triggers.md
@@ -46,14 +46,7 @@
 
 ## TS / JS 语法糖
 
-| 模式                      | 搜什么                                                     |
-| ------------------------- | ---------------------------------------------------------- | --- | ----------------------------------- | --- | ----------------------------------- |
-| `using` / `await using`   | `"TypeScript using declaration support"` + 是否需 polyfill |
-| `Promise.withResolvers()` | `"Promise.withResolvers browser support"`                  |
-| `structuredClone`         | `"structuredClone browser support"`                        |
-| `satisfies`               | 一般 OK，看 TS 版本                                        |
-| `??` / `??=` vs `         |                                                            | `   | `"nullish coalescing pitfalls"`（`x |     | default` 在 0/''/false 时错误兜底） |
-| Top-level await           | Nuxt/Vite 支持情况                                         |
+| 模式 | 搜什么 | | ------------------------- | ---------------------------------------------------------- | --- | ----------------------------------- | --- | ----------------------------------- | | `using` / `await using` | `"TypeScript using declaration support"` + 是否需 polyfill | | `Promise.withResolvers()` | `"Promise.withResolvers browser support"` | | `structuredClone` | `"structuredClone browser support"` | | `satisfies` | 一般 OK，看 TS 版本 | | `??` / `??=` vs `        |                                                            |` | `"nullish coalescing pitfalls"`（`x |     | default` 在 0/''/false 时错误兜底） | | Top-level await | Nuxt/Vite 支持情况 |
 
 ## 类型断言 / 绕过
 

--- a/apps/slax-reader-dweb/layers/core/app/pages/bookmarks/index.vue
+++ b/apps/slax-reader-dweb/layers/core/app/pages/bookmarks/index.vue
@@ -195,14 +195,14 @@ const { inboxState } = useInboxOnboardingState({
   userId: computed(() => userStore.userInfo?.userId)
 })
 
-// 状态 A → 跳转 /onboarding（暂时下线，下周再上）
-// watch(
-//   inboxState,
-//   state => {
-//     if (state === 'A') navigateTo('/onboarding', { replace: true })
-//   },
-//   { immediate: true }
-// )
+// 状态 A → 跳转 /onboarding
+watch(
+  inboxState,
+  state => {
+    if (state === 'A') navigateTo('/onboarding', { replace: true })
+  },
+  { immediate: true }
+)
 
 const addLog = () => {
   const sectionMap: Record<string, 'inbox' | 'starred' | 'topics' | 'highlights' | 'archive' | 'trash' | 'notifications'> = {

--- a/apps/slax-reader-dweb/nuxt.config.ts
+++ b/apps/slax-reader-dweb/nuxt.config.ts
@@ -239,7 +239,7 @@ export default defineNuxtConfig({
           sizes: '512x512',
           type: 'image/png'
         }
-      ],
+      ]
     },
     scope: '/',
     registerWebManifestInRouteRules: true,

--- a/apps/slax-reader-dweb/tests/integration/pages/bookmarks/index.spec.ts
+++ b/apps/slax-reader-dweb/tests/integration/pages/bookmarks/index.spec.ts
@@ -287,12 +287,12 @@ describe('pages/bookmarks/index.vue', () => {
       expect(wrapper.findComponent({ name: 'BookmarksEmptyView' }).exists()).toBe(false)
     })
 
-    it('C7: 默认 inbox + isDataEmpty=true + 未装插件 → 状态 A（跳转逻辑暂时下线，不触发 navigateTo），列表侧按状态 B 展示（非通用 EmptyView）', async () => {
+    it('C7: 默认 inbox + isDataEmpty=true + 未装插件 → 跳转 /onboarding，列表侧按状态 B 展示（非通用 EmptyView）', async () => {
       mockUseExtensionDetection.mockReturnValue({ isInstalled: { value: false }, checked: { value: true } })
       const wrapper = mountIndexPage()
       await flushPromises()
-      // 跳转 watch 暂时注释，恢复时把这两行换回 toHaveBeenCalledWith
-      expect(mockNavigateTo).not.toHaveBeenCalledWith('/onboarding', expect.anything())
+      // 状态 A → 跳转 + 按 B 展示
+      expect(mockNavigateTo).toHaveBeenCalledWith('/onboarding', { replace: true })
       expect(wrapper.findComponent({ name: 'BookmarksEmptyView' }).exists()).toBe(true)
     })
 

--- a/apps/slax-reader-extensions/src/config/panel.ts
+++ b/apps/slax-reader-extensions/src/config/panel.ts
@@ -28,14 +28,14 @@ import starHighlightedImage from '~/assets/panel-item-star-highlighted.png'
 import starSelectedImage from '~/assets/panel-item-star-selected.png'
 
 export enum PanelItemType {
-  'AI' = 'ai',
-  'Outline' = 'outline',
-  'Chat' = 'chat',
-  'Share' = 'share',
-  'Comments' = 'comments',
-  'Archieve' = 'archieve',
-  'Star' = 'star',
-  'Feedback' = 'feedback'
+  AI = 'ai',
+  Outline = 'outline',
+  Chat = 'chat',
+  Share = 'share',
+  Comments = 'comments',
+  Archieve = 'archieve',
+  Star = 'star',
+  Feedback = 'feedback'
 }
 
 export interface PanelItem {

--- a/commons/types/src/analytics.ts
+++ b/commons/types/src/analytics.ts
@@ -244,13 +244,7 @@ export type WebAnalyticsEvent =
  * Extension 端埋点事件类型
  */
 export type ExtensionAnalyticsEvent =
-  | BookmarkArchiveEvent
-  | BookmarkStarEvent
-  | BookmarkChatInteractEvent
-  | BookmarkOverviewInteractEvent
-  | BookmarkOutlineInteractEvent
-  | FeedbackSubmitStartEvent
-  | BookmarkViewEvent
+  BookmarkArchiveEvent | BookmarkStarEvent | BookmarkChatInteractEvent | BookmarkOverviewInteractEvent | BookmarkOutlineInteractEvent | FeedbackSubmitStartEvent | BookmarkViewEvent
 
 // ==================== 工具类型 ====================
 


### PR DESCRIPTION
## Summary
- Uncomment the `navigateTo('/onboarding')` watch on state A in `bookmarks/index.vue`, previously disabled by request pending product sign-off.
- Restore the matching integration test assertion (C7) that expects the redirect to fire.
- Runs `prettier --write` on 4 unrelated pre-existing files that were failing the repo-wide `format:check` pre-commit hook, blocking this commit.

## Testing
- `pnpm exec vitest run tests/integration/pages/bookmarks/` — 83/83 passing
- `pnpm exec eslint` on touched files — no new errors (pre-existing warnings only)