### PR TITLE
✨ Add REST-backed source filtering to inbox

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/composables/bookmark/useBookmarkData.ts
+++ b/apps/slax-reader-dweb/layers/core/app/composables/bookmark/useBookmarkData.ts
@@ -1,7 +1,7 @@
 // 书签列表数据层：列表状态 + 分页 + 查询 + 无限滚动 + 派生计算 + cell handlers + 频道同步
 // 依赖方向：单向依赖 useBookmarkFilter（读 filter ref）+ 页面传入的 searchText，无构造期循环依赖。
 // scrollY（useScroll）归页面持有，不在此处。
-import { computed, onActivated, onDeactivated, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onActivated, onDeactivated, onMounted, onUnmounted, ref, toValue, watch } from 'vue'
 
 import { isClient } from '@commons/utils/is'
 import type { ChannelMessageData } from '#layers/core/app/utils/channel'
@@ -17,7 +17,7 @@ type BookmarkFilter = ReturnType<typeof useBookmarkFilter>
 // 日期分组条目类型
 type GroupedItem = { type: 'group'; label: string; key: string } | { type: 'bookmark'; bookmark: BookmarkItem; index: number }
 
-export const useBookmarkData = (filter: BookmarkFilter, searchText: Ref<string>) => {
+export const useBookmarkData = (filter: BookmarkFilter, searchText: Ref<string>, sourceDomain?: Ref<string | null | undefined>) => {
   const { t, locale } = useI18n()
 
   const bookmarks = ref<BookmarkItem[]>([])
@@ -113,6 +113,7 @@ export const useBookmarkData = (filter: BookmarkFilter, searchText: Ref<string>)
   // === 查询 ===
 
   const queryBookmarks = async () => {
+    const source = toValue(sourceDomain)
     return await request().get<BookmarkItem[]>({
       url: RESTMethodPath.BOOKMARK_LIST,
       query: {
@@ -120,7 +121,8 @@ export const useBookmarkData = (filter: BookmarkFilter, searchText: Ref<string>)
         size: 20,
         filter: `${filter.filterStatus.value}`,
         topic_ids: filter.filterTopicIds.value.join(','),
-        collection_id: String(filter.filterCollectionId.value) || ''
+        collection_id: String(filter.filterCollectionId.value) || '',
+        ...(filter.filterStatus.value === 'inbox' && source ? { source } : {})
       }
     })
   }
@@ -218,6 +220,14 @@ export const useBookmarkData = (filter: BookmarkFilter, searchText: Ref<string>)
   const reloadList = () => {
     resetBookmarks()
     onLoadMore()
+  }
+
+  if (sourceDomain) {
+    watch(sourceDomain, (domain, previousDomain) => {
+      if (domain === previousDomain || filter.filterStatus.value !== 'inbox') return
+      resetBookmarks()
+      onLoadMore()
+    })
   }
 
   // === 无限滚动 ===

--- a/apps/slax-reader-dweb/layers/core/app/pages/bookmarks/index.vue
+++ b/apps/slax-reader-dweb/layers/core/app/pages/bookmarks/index.vue
@@ -41,14 +41,28 @@
             !searchText &&
             !['highlights', 'notifications'].includes(filterStatus) &&
             !(filterStatus === 'topics' && filterTopicIds.length < 1) &&
-            !(isDataEmpty && !isTransitioning)
+            !(isDataEmpty && !isTransitioning && !sourceFilter)
           "
           v-model="listMode"
           :last-updated-text="lastUpdatedText"
-        />
+          :show-leading="!!sourceFilter"
+        >
+          <template #leading>
+            <div v-if="sourceFilter" class="source-filter-tag">
+              <span class="source-filter-prefix">{{ $t('page.bookmarks_index.source_filter_site') }}:</span>
+              <span class="source-filter-label">{{ sourceFilter.label }}</span>
+              <button class="source-filter-close" type="button" :aria-label="$t('common.operate.cancel')" @click="clearSourceFilter">
+                <svg viewBox="0 0 16 16" aria-hidden="true">
+                  <path d="M4 4l8 8M12 4l-8 8" />
+                </svg>
+              </button>
+            </div>
+          </template>
+        </ListLayoutSwitcher>
 
         <BookmarkListContent
           v-if="showList"
+          :key="`${filterStatus}:${filterTopicIds.join(',')}:${filterCollectionId}:${sourceFilter?.domain || ''}`"
           :filter-status="filterStatus"
           :grouped-bookmarks="groupedBookmarks"
           :highlights="highlights"
@@ -59,6 +73,7 @@
           @archive-update="handleCellArchive"
           @alias-title-update="handleCellAliasTitle"
           @bookmark-update="handleCellBookmarkUpdate"
+          @source-filter="applySourceFilter"
           @select-tag="selectTagFromCell"
         />
         <template v-if="!(isTransitioning && isDataEmpty) && !searchText">
@@ -129,6 +144,7 @@ const userStore = useUserStore()
 const searchText = ref('')
 const isSearching = ref(false)
 const isShowTopModal = ref(false)
+const sourceFilter = ref<{ domain: string; label: string } | null>(null)
 
 // 筛选状态 + 纯导航 helper（编排动作 selectTopic/selectCollection/inboxClick 留在本页）
 const {
@@ -179,7 +195,8 @@ const {
     applyCollection,
     applyTab
   },
-  searchText
+  searchText,
+  computed(() => sourceFilter.value?.domain)
 )
 
 // 列表布局模式（card / text），localStorage 持久化
@@ -239,7 +256,12 @@ watch(filterStatus, (value, oldValue) => {
     return
   }
 
+  if (value !== 'inbox') sourceFilter.value = null
   reloadList()
+})
+
+watch(searchText, value => {
+  if (value) sourceFilter.value = null
 })
 
 // 刷新指示器：首屏加载时延迟 250ms 展示顶部 spinner
@@ -257,6 +279,7 @@ onMounted(() => {
 
 // 编排动作：选择一组话题（交集）。filterStatus 不变（始终 'topics'），故手动 reset + load
 const selectTopics = async (ids: string[], name = '') => {
+  sourceFilter.value = null
   resetBookmarks()
   await applyTopics(ids, name)
   await onLoadMore()
@@ -264,6 +287,7 @@ const selectTopics = async (ids: string[], name = '') => {
 
 // 编排动作：列表卡片上点了一个标签 → 进标签筛选页，只选这一个
 const selectTagFromCell = async (tag: BookmarkTag) => {
+  sourceFilter.value = null
   const ids = [String(tag.id)]
   if (filterStatus.value === 'topics') {
     await selectTopics(ids, tag.show_name)
@@ -283,6 +307,7 @@ const selectTagFromCell = async (tag: BookmarkTag) => {
 
 // 编排动作：选择合集。filterStatus 不变（始终 'collections'），故手动 reset + load
 const selectCollection = async (info: { id: number; name: string; code: string } | null) => {
+  sourceFilter.value = null
   resetBookmarks()
   await applyCollection(info)
   await onLoadMore()
@@ -300,6 +325,7 @@ const inboxClick = async (type: string, index?: number) => {
     return
   }
 
+  sourceFilter.value = null
   resetBookmarks()
   await applyTab(type)
 
@@ -307,6 +333,17 @@ const inboxClick = async (type: string, index?: number) => {
     const button = tabsSidebar.value?.getAllButtons()[index]
     button?.scrollIntoView({ behavior: 'smooth', block: 'center' })
   }
+}
+
+const applySourceFilter = (source: { domain: string; label: string }) => {
+  if (filterStatus.value !== 'inbox' || !source.domain) return
+  sourceFilter.value = source
+  y.value = 0
+}
+
+const clearSourceFilter = () => {
+  sourceFilter.value = null
+  y.value = 0
 }
 
 const addUrlSuccess = () => {
@@ -339,6 +376,55 @@ const notificationBack = () => {
 </script>
 
 <style lang="scss" scoped>
+.source-filter-tag {
+  display: inline-flex;
+  align-items: center;
+  max-width: min(100%, 320px);
+  padding: 5px 10px;
+  border: 1px solid color-mix(in srgb, var(--slax-accent) 24%, var(--slax-border));
+  border-radius: 999px;
+  background: var(--slax-accent-bg);
+  color: var(--slax-accent);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.source-filter-prefix {
+  flex-shrink: 0;
+  margin-right: 4px;
+}
+
+.source-filter-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-filter-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  margin-left: 6px;
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  color: currentColor;
+  cursor: pointer;
+
+  svg {
+    width: 12px;
+    height: 12px;
+    flex: 0 0 12px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.5;
+    stroke-linecap: round;
+  }
+}
+
 .list-loading-enter-active,
 .list-loading-leave-active {
   transition: transform 0.4s;

--- a/apps/slax-reader-dweb/layers/core/i18n/locales/en.json
+++ b/apps/slax-reader-dweb/layers/core/i18n/locales/en.json
@@ -566,6 +566,7 @@
       "add_article": "Add article",
       "date_group_format": "{monthName} {year}",
       "last_updated_at": "Updated {time}",
+      "source_filter_site": "Site",
       "just_now": "just now",
       "minutes_ago": "{n} minutes ago",
       "hours_ago": "{n} hours ago",

--- a/apps/slax-reader-dweb/layers/core/i18n/locales/zh.json
+++ b/apps/slax-reader-dweb/layers/core/i18n/locales/zh.json
@@ -566,6 +566,7 @@
       "add_article": "添加文章",
       "date_group_format": "{year} 年 {month} 月",
       "last_updated_at": "最近更新于 {time}",
+      "source_filter_site": "站点",
       "just_now": "刚刚",
       "minutes_ago": "{n} 分钟前",
       "hours_ago": "{n} 小时前",

--- a/apps/slax-reader-dweb/tests/unit/composables/bookmark/useBookmarkData.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/composables/bookmark/useBookmarkData.spec.ts
@@ -13,6 +13,7 @@ import { flushPromises } from '@vue/test-utils'
 import { baseBookmarkItem } from '~~/tests/fixtures/bookmark'
 import { mountWithApp } from '~~/tests/setup/mount'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Ref } from 'vue'
 
 const { mockRequest, mockGet, mockPost, mockAddChannelMessageHandler, mockRemoveChannelMessageHandler, capturedChannelHandler, mockUseI18n, mockT } = vi.hoisted(() => {
   const captured: { value: any } = { value: null }
@@ -76,11 +77,11 @@ const makeFilter = (overrides: Partial<Record<string, any>> = {}): ReturnType<ty
 }
 
 // 通过最小宿主组件挂载 useBookmarkData，暴露其返回值供断言
-const mountData = (filter: ReturnType<typeof useBookmarkFilter>, searchText = ref('')) => {
+const mountData = (filter: ReturnType<typeof useBookmarkFilter>, searchText = ref(''), sourceDomain?: Ref<string | undefined>) => {
   let api: ReturnType<typeof useBookmarkData> | undefined
   const Host = defineComponent({
     setup() {
-      api = useBookmarkData(filter, searchText)
+      api = useBookmarkData(filter, searchText, sourceDomain)
       return () => null
     }
   })
@@ -100,6 +101,21 @@ describe('useBookmarkData', () => {
   })
 
   describe('loadData 分页 + ending', () => {
+    it('inbox source filter is sent to REST and changing it restarts from page 1', async () => {
+      mockGet.mockResolvedValueOnce([]).mockResolvedValueOnce([{ ...baseBookmarkItem, id: 1 }])
+      const sourceDomain = ref<string | undefined>()
+      const { api } = mountData(makeFilter(), ref(''), sourceDomain)
+      await flushPromises()
+
+      sourceDomain.value = 'example.com'
+      await flushPromises()
+
+      expect(mockGet).toHaveBeenCalledTimes(2)
+      const sourceRequest = mockGet.mock.calls[1]?.[0]
+      expect(sourceRequest).toEqual(expect.objectContaining({ query: expect.objectContaining({ page: 1, source: 'example.com' }) }))
+      expect(api.bookmarks.value.map(bookmark => bookmark.id)).toEqual([1])
+    })
+
     it('加载中途 reset，过期响应丢掉，不重复 push、page 不动', async () => {
       let resolveFirst: (v: any) => void = () => {}
       mockGet.mockReturnValueOnce(new Promise(resolve => (resolveFirst = resolve)))


### PR DESCRIPTION
## Summary\n- Send the selected source domain to the bookmark list API.\n- Reset REST pagination when the source changes or is cleared.\n- Wire the existing source filter UI into the inbox page.\n\n## Validation\n- Updated the bookmark data composable test coverage.\n- Lint passes for the changed files.