### PR TITLE
🐛 fix tag-add popup clipped by next list cell

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkCell.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkCell.vue
@@ -548,11 +548,6 @@ const starBookmark = async (isStar: boolean) => {
   display: flex;
   align-items: flex-start;
   gap: 16px;
-
-  // 标签面板开着时抬高整卡，不被下一张卡的 body 压住
-  &:has(.search-list) {
-    z-index: 5;
-  }
   padding: 18px 20px;
   background: var(--slax-surface);
   border: 1px solid var(--slax-border);

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksEmptyState.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksEmptyState.vue
@@ -22,7 +22,6 @@
 <script setup lang="ts">
 import BookmarksEmptyView from '#layers/core/app/components/BookmarkList/BookmarksEmptyView.vue'
 
-import { eventLog } from '@/utils/analytics'
 import { isMobileBrowser } from '#layers/core/app/utils/environment'
 
 import type { InboxOnboardingState } from '#layers/core/app/composables/bookmark/useInboxOnboardingState'
@@ -40,7 +39,7 @@ const isMobile = isMobileBrowser()
 
 const pluginUrl = 'https://chromewebstore.google.com/detail/slax-reader/gdnhaajlomjkhahnmiijphnodkcfikfd?utm_source=web_empty_state'
 const installExtension = () => {
-  eventLog({ event_name: 'element_clicked', properties: { element_id: 'empty_state_install_cta', screen_name: 'bookmarks' } })
+  analyticsLog({ event: 'bookmark_list_download', client: 'browser_extension' })
   window.open(pluginUrl)
 }
 

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksSearchBar.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksSearchBar.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- 顶栏内嵌搜索框：支持历史记录下拉、回车搜索、Esc 收起 -->
   <!-- click-outside 绑在容器上，避免 input focus 时被误判为外部点击导致历史闪烁 -->
-  <div class="topbar-search" data-analytics-element="bookmark_search" :class="{ focused: isFocused }" ref="searchWrap" v-on-click-outside="onClickOutside">
+  <div class="topbar-search" :class="{ focused: isFocused }" ref="searchWrap" v-on-click-outside="onClickOutside">
     <!-- 搜索图标 -->
     <svg class="search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <circle cx="11" cy="11" r="8" />
@@ -12,6 +12,7 @@
     <input
       v-ime-guard
       class="search-input"
+      data-analytics-element="bookmark_search"
       :placeholder="$t('page.bookmarks_index.search_placeholder')"
       v-model="keyword"
       @focus="onFocus"

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkTags.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkTags.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bookmark-tags" ref="bookmarkTagsEle">
+  <div class="bookmark-tags">
     <div class="tags-list" :class="{ 'is-reserving': isReserving }">
       <!-- :key 随 id 集合变化整块挂卸，
            绕开 keyed v-for patch 崩溃 -->
@@ -29,45 +29,49 @@
             </g>
           </svg>
         </button>
-        <!-- v-if 而非 v-show：整子树挂卸。
-             local-first 下 v-for 吃的是 PowerSync 的 live useQuery，隐藏时 patch 会崩 -->
-        <div v-if="isAddingTag" class="search-list" ref="searchList" v-on-click-outside="[onClickOutside, { ignore: [add] }]">
-          <input
-            ref="searchInput"
-            v-ime-guard
-            type="text"
-            :placeholder="$t('component.bookmark_tags.placeholder')"
-            v-model="searchText"
-            v-on-key-stroke:Enter="[onKeyDown, { eventName: 'keydown' }]"
-          />
-          <div class="search-result">
-            <div class="result-wrapper" ref="resultWrapper" v-if="groupedCandidates.length > 0 || createName" @scroll="onResultScroll">
-              <template v-for="group in groupedCandidates" :key="group.key">
-                <div class="group-heading">{{ $t(group.label) }}</div>
-                <div
-                  v-for="tag in group.tags"
-                  :key="tag.id"
-                  class="search-tag"
-                  :class="{ active: pending.has(String(tag.id)), attached: attachedIds.has(String(tag.id)) }"
-                  @click="toggleCandidate(tag)"
-                >
-                  <span class="tag-name">{{ tag.show_name }}</span>
-                  <i class="check" v-if="pending.has(String(tag.id)) || attachedIds.has(String(tag.id))" />
+        <!-- Teleport 到 body：列表卡片位于 virtua 虚拟滚动的 item wrapper 内（该 wrapper 带
+             contain:layout style，会形成独立层叠上下文），面板留在卡片内部时无论 z-index
+             多高都逃不出这层 containment，会被下一张卡片盖住。挪到 body 顶层 + fixed 定位彻底绕开。
+             v-if 而非 v-show：整子树挂卸。local-first 下 v-for 吃的是 PowerSync 的 live useQuery，隐藏时 patch 会崩 -->
+        <Teleport to="body">
+          <div v-if="isAddingTag" class="search-list" ref="searchList" :style="popupStyle" v-on-click-outside="[onClickOutside, { ignore: [add] }]">
+            <input
+              ref="searchInput"
+              v-ime-guard
+              type="text"
+              :placeholder="$t('component.bookmark_tags.placeholder')"
+              v-model="searchText"
+              v-on-key-stroke:Enter="[onKeyDown, { eventName: 'keydown' }]"
+            />
+            <div class="search-result">
+              <div class="result-wrapper" ref="resultWrapper" v-if="groupedCandidates.length > 0 || createName" @scroll="onResultScroll">
+                <template v-for="group in groupedCandidates" :key="group.key">
+                  <div class="group-heading">{{ $t(group.label) }}</div>
+                  <div
+                    v-for="tag in group.tags"
+                    :key="tag.id"
+                    class="search-tag"
+                    :class="{ active: pending.has(String(tag.id)), attached: attachedIds.has(String(tag.id)) }"
+                    @click="toggleCandidate(tag)"
+                  >
+                    <span class="tag-name">{{ tag.show_name }}</span>
+                    <i class="check" v-if="pending.has(String(tag.id)) || attachedIds.has(String(tag.id))" />
+                  </div>
+                </template>
+                <div v-if="createName" class="search-tag create" :class="{ active: pending.has(newKey(createName)) }" @click="togglePending(newKey(createName))">
+                  <span class="tag-name">{{ $t('component.bookmark_tags.create', { name: createName }) }}</span>
+                  <i class="check" v-if="pending.has(newKey(createName))" />
                 </div>
-              </template>
-              <div v-if="createName" class="search-tag create" :class="{ active: pending.has(newKey(createName)) }" @click="togglePending(newKey(createName))">
-                <span class="tag-name">{{ $t('component.bookmark_tags.create', { name: createName }) }}</span>
-                <i class="check" v-if="pending.has(newKey(createName))" />
               </div>
             </div>
+            <div class="panel-footer">
+              <button type="button" class="confirm-btn" @click="commitPending">{{ $t('component.bookmark_tags.confirm', { n: pending.size }) }}</button>
+            </div>
+            <div class="list-loading" v-if="isAddingLoading">
+              <div class="i-svg-spinners:90-ring w-24px" style="color: var(--slax-accent)" />
+            </div>
           </div>
-          <div class="panel-footer">
-            <button type="button" class="confirm-btn" @click="commitPending">{{ $t('component.bookmark_tags.confirm', { n: pending.size }) }}</button>
-          </div>
-          <div class="list-loading" v-if="isAddingLoading">
-            <div class="i-svg-spinners:90-ring w-24px" style="color: var(--slax-accent)" />
-          </div>
-        </div>
+        </Teleport>
       </div>
     </div>
   </div>
@@ -135,11 +139,12 @@ const sharedUserTags = props.compact ? inject(SharedUserTagsKey, null) : null
 const isMounted = ref(false)
 const localActive = computed(() => isMounted.value && tagSrc.value !== null)
 
-const bookmarkTagsEle = ref<HTMLDivElement>()
 const add = ref<HTMLButtonElement>()
 const searchList = ref<HTMLDivElement>()
 const searchInput = ref<HTMLInputElement>()
 const resultWrapper = ref<HTMLDivElement>()
+// 面板 fixed 定位：viewport 坐标，随外层滚动/resize 更新
+const popupStyle = ref<{ top: string; left: string }>({ top: '0px', left: '0px' })
 
 // 双轨：LF 只读 / REST ref
 const restBookmarkTags = ref<BookmarkTag[]>(props.tags || [])
@@ -226,20 +231,21 @@ watch(
   { deep: true }
 )
 
+// 按 + 按钮当前位置算 fixed 坐标（viewport 绝对值，Teleport 到 body 后不再受任何祖先 transform/offset 影响）
+const updatePopupPosition = () => {
+  const rect = add.value?.getBoundingClientRect()
+  if (!rect) return
+  popupStyle.value = { top: `${rect.bottom + 10}px`, left: `${rect.left}px` }
+}
+
 watch(
   () => isAddingTag.value,
   value => {
     if (!value) return
-    // v-if 弹层，nextTick 再定位/聚焦
+    updatePopupPosition()
+    // v-if 弹层，nextTick 再定位/聚焦（首次挂载时 rect 更准）
     nextTick(() => {
-      const eleRect = bookmarkTagsEle.value?.getBoundingClientRect()
-      const rect = add.value?.getBoundingClientRect()
-      if (eleRect && rect && searchList.value) {
-        const yOffset = rect.bottom - eleRect.top + 10
-        const xOffset = rect.left - eleRect.left
-        searchList.value.style.top = `${yOffset}px`
-        searchList.value.style.left = `${xOffset}px`
-      }
+      updatePopupPosition()
       searchInput.value?.focus()
       restoreResultScroll()
     })
@@ -247,8 +253,21 @@ watch(
   }
 )
 
+// 面板开着时列表所在容器（inbox 主区域/文章侧栏）可能滚动，+ 按钮位置会变，需跟随重新定位
+const onReposition = () => {
+  if (!isAddingTag.value) return
+  updatePopupPosition()
+}
+
 onMounted(() => {
   isMounted.value = true
+  window.addEventListener('scroll', onReposition, { passive: true, capture: true })
+  window.addEventListener('resize', onReposition, { passive: true })
+})
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', onReposition, true)
+  window.removeEventListener('resize', onReposition)
 })
 
 const onResultScroll = (e: Event) => {
@@ -486,7 +505,8 @@ const addingTagClick = (e: MouseEvent) => {
 }
 
 .search-list {
-  --style: absolute top-full -mt-2px w-260px rounded-sm overflow-hidden border-(1px solid border) shadow-warm bg-surface-solid px-12px py-16px pb-12px z-10;
+  // fixed 定位（Teleport 到 body），top/left 由脚本按 + 按钮 rect 算好写进 style
+  --style: fixed w-260px rounded-sm overflow-hidden border-(1px solid border) shadow-warm bg-surface-solid px-12px py-16px pb-12px z-200;
 
   input {
     --style: rounded-sm bg-surface border-(1px solid border) px-10px py-9px h-36px text-(aux txt-light) line-height-18px w-full transition-all duration-300;

--- a/apps/slax-reader-dweb/layers/core/app/error.vue
+++ b/apps/slax-reader-dweb/layers/core/app/error.vue
@@ -94,7 +94,7 @@ const errorMessage = computed(() => {
     padding-top: var(--slax-header-height);
 
     .slug-container {
-      --style: flex-center flex-col;
+      --style: flex-center flex-col z-2;
 
       .empty-illustration {
         color: var(--slax-text-muted);

--- a/apps/slax-reader-dweb/layers/core/app/pages/[...slug].vue
+++ b/apps/slax-reader-dweb/layers/core/app/pages/[...slug].vue
@@ -68,7 +68,7 @@ const logoClick = () => {
     padding-top: var(--slax-header-height);
 
     .slug-container {
-      --style: flex-center flex-col;
+      --style: flex-center flex-col z-2;
 
       .empty-illustration {
         color: var(--slax-text-muted);

--- a/apps/slax-reader-dweb/tests/fixtures/20260908-bookmark-export-browser.html
+++ b/apps/slax-reader-dweb/tests/fixtures/20260908-bookmark-export-browser.html
@@ -1,29 +1,175 @@
 <!doctype html>
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>Saved-link export browser validation</title>
-<style>body{font:16px system-ui;max-width:900px;margin:40px auto}button{padding:12px;margin:8px}pre{white-space:pre-wrap}</style>
+<style>
+  body {
+    font: 16px system-ui;
+    max-width: 900px;
+    margin: 40px auto;
+  }
+  button {
+    padding: 12px;
+    margin: 8px;
+  }
+  pre {
+    white-space: pre-wrap;
+  }
+</style>
 <h1>Saved-link export browser validation</h1>
 <p>Synthetic data only. Each run exports 100,000 links in 200 pages through the production export utility.</p>
 <button id="csv">Run CSV</button><button id="json">Run JSON</button><button id="cancelTest">Test cancellation</button>
-<p id="progress">Ready</p><pre id="result"></pre>
+<p id="progress">Ready</p>
+<pre id="result"></pre>
 <script type="module">
-import {prepareBookmarkExport} from './export.js';
-const progress=document.querySelector('#progress'), result=document.querySelector('#result');
-const makeItem=i=>({url:`https://example.com/saved/${i}`,title:`${i%3?'文章':'=SUM(1,2)'} ${i}, "quoted"\nsecond line 🐈`,tags:[{name:'阅读, "标签"',source:'ai'},{name:'work\nnotes',source:'user'}],saved_at:'2026-09-08T00:00:00.000Z',is_read:i%2===0,is_archived:i%3===0,is_starred:i%5===0,type:i%7===0?'shortcut':'article'});
-function parseCsv(text){let rows=[],row=[],cell='',quote=false;for(let i=0;i<text.length;i++){let c=text[i];if(c==='"'){if(quote&&text[i+1]==='"'){cell+='"';i++}else quote=!quote}else if(c===','&&!quote){row.push(cell);cell=''}else if(c==='\n'&&!quote){row.push(cell.replace(/\r$/,''));rows.push(row);row=[];cell=''}else cell+=c}return rows}
-async function run(format,cancel=false){
- document.querySelectorAll('button').forEach(b=>b.disabled=true);result.textContent='';
- const controller=new AbortController();let pages=0,count=0,peak=0,cancelAt=0,maxTickGap=0,last=performance.now();
- const start=performance.now(),before=performance.memory?.usedJSHeapSize??null;
- const timer=setInterval(()=>{const now=performance.now();maxTickGap=Math.max(maxTickGap,now-last);last=now;peak=Math.max(peak,performance.memory?.usedJSHeapSize??0)},10);
- try {
-  const output=await prepareBookmarkExport({format,signal:controller.signal,fetchPage:async(cursor,signal)=>{signal.throwIfAborted();pages++;const from=Number(cursor||0);return {items:Array.from({length:500},(_,j)=>makeItem(from+j)),next_cursor:from+500<100000?String(from+500):null}},onProgress:n=>{count=n;progress.textContent=`Prepared ${n} links`;if(cancel&&n===10000){setTimeout(()=>{cancelAt=performance.now();controller.abort()},0)}}});
-  const built=performance.now(),after=performance.memory?.usedJSHeapSize??null;clearInterval(timer);
-  const bytes=output.blob.size;const text=await output.blob.text();let verified=0;
-  if(format==='json'){const obj=JSON.parse(text);if(obj.schema_version!==1||obj.items.length!==100000)throw Error('JSON count/version mismatch');for(let i=0;i<obj.items.length;i++){if(JSON.stringify(obj.items[i])!==JSON.stringify(makeItem(i)))throw Error(`JSON record mismatch ${i}`);verified++}}
-  else {const rows=parseCsv(text.replace(/^\uFEFF/,''));if(rows.length!==100001)throw Error(`CSV count mismatch ${rows.length}`);for(let i=0;i<100000;i++){const item=makeItem(i),row=rows[i+1];const expected=[item.url,item.title.startsWith('=')?"'"+item.title:item.title,JSON.stringify(item.tags.map(t=>t.name)),item.saved_at,String(item.is_read),String(item.is_archived),String(item.is_starred),item.type];if(JSON.stringify(row)!==JSON.stringify(expected))throw Error(`CSV mismatch ${i}`);verified++}}
-  result.textContent=JSON.stringify({status:'passed',format,count:output.count,pages,verified,bytes,prepare_ms:Math.round(built-start),heap_before:before,heap_after:after,heap_peak_sample:peak,max_timer_gap_ms:Math.round(maxTickGap),heap_note:'Browser performance.memory is approximate; excludes Blob backing storage'},null,2);
- }catch(error){result.textContent=JSON.stringify({status:cancel&&error.name==='AbortError'?'cancelled':'failed',error:error.name,count,pages,cancel_latency_ms:cancelAt?Math.round(performance.now()-cancelAt):null,partial_download:false},null,2)}finally{clearInterval(timer);document.querySelectorAll('button').forEach(b=>b.disabled=false)}
-}
-document.querySelector('#csv').onclick=()=>run('csv');document.querySelector('#json').onclick=()=>run('json');document.querySelector('#cancelTest').onclick=()=>run('csv',true);
+  import { prepareBookmarkExport } from './export.js'
+  const progress = document.querySelector('#progress'),
+    result = document.querySelector('#result')
+  const makeItem = i => ({
+    url: `https://example.com/saved/${i}`,
+    title: `${i % 3 ? '文章' : '=SUM(1,2)'} ${i}, "quoted"\nsecond line 🐈`,
+    tags: [
+      { name: '阅读, "标签"', source: 'ai' },
+      { name: 'work\nnotes', source: 'user' }
+    ],
+    saved_at: '2026-09-08T00:00:00.000Z',
+    is_read: i % 2 === 0,
+    is_archived: i % 3 === 0,
+    is_starred: i % 5 === 0,
+    type: i % 7 === 0 ? 'shortcut' : 'article'
+  })
+  function parseCsv(text) {
+    let rows = [],
+      row = [],
+      cell = '',
+      quote = false
+    for (let i = 0; i < text.length; i++) {
+      let c = text[i]
+      if (c === '"') {
+        if (quote && text[i + 1] === '"') {
+          cell += '"'
+          i++
+        } else quote = !quote
+      } else if (c === ',' && !quote) {
+        row.push(cell)
+        cell = ''
+      } else if (c === '\n' && !quote) {
+        row.push(cell.replace(/\r$/, ''))
+        rows.push(row)
+        row = []
+        cell = ''
+      } else cell += c
+    }
+    return rows
+  }
+  async function run(format, cancel = false) {
+    document.querySelectorAll('button').forEach(b => (b.disabled = true))
+    result.textContent = ''
+    const controller = new AbortController()
+    let pages = 0,
+      count = 0,
+      peak = 0,
+      cancelAt = 0,
+      maxTickGap = 0,
+      last = performance.now()
+    const start = performance.now(),
+      before = performance.memory?.usedJSHeapSize ?? null
+    const timer = setInterval(() => {
+      const now = performance.now()
+      maxTickGap = Math.max(maxTickGap, now - last)
+      last = now
+      peak = Math.max(peak, performance.memory?.usedJSHeapSize ?? 0)
+    }, 10)
+    try {
+      const output = await prepareBookmarkExport({
+        format,
+        signal: controller.signal,
+        fetchPage: async (cursor, signal) => {
+          signal.throwIfAborted()
+          pages++
+          const from = Number(cursor || 0)
+          return { items: Array.from({ length: 500 }, (_, j) => makeItem(from + j)), next_cursor: from + 500 < 100000 ? String(from + 500) : null }
+        },
+        onProgress: n => {
+          count = n
+          progress.textContent = `Prepared ${n} links`
+          if (cancel && n === 10000) {
+            setTimeout(() => {
+              cancelAt = performance.now()
+              controller.abort()
+            }, 0)
+          }
+        }
+      })
+      const built = performance.now(),
+        after = performance.memory?.usedJSHeapSize ?? null
+      clearInterval(timer)
+      const bytes = output.blob.size
+      const text = await output.blob.text()
+      let verified = 0
+      if (format === 'json') {
+        const obj = JSON.parse(text)
+        if (obj.schema_version !== 1 || obj.items.length !== 100000) throw Error('JSON count/version mismatch')
+        for (let i = 0; i < obj.items.length; i++) {
+          if (JSON.stringify(obj.items[i]) !== JSON.stringify(makeItem(i))) throw Error(`JSON record mismatch ${i}`)
+          verified++
+        }
+      } else {
+        const rows = parseCsv(text.replace(/^\uFEFF/, ''))
+        if (rows.length !== 100001) throw Error(`CSV count mismatch ${rows.length}`)
+        for (let i = 0; i < 100000; i++) {
+          const item = makeItem(i),
+            row = rows[i + 1]
+          const expected = [
+            item.url,
+            item.title.startsWith('=') ? "'" + item.title : item.title,
+            JSON.stringify(item.tags.map(t => t.name)),
+            item.saved_at,
+            String(item.is_read),
+            String(item.is_archived),
+            String(item.is_starred),
+            item.type
+          ]
+          if (JSON.stringify(row) !== JSON.stringify(expected)) throw Error(`CSV mismatch ${i}`)
+          verified++
+        }
+      }
+      result.textContent = JSON.stringify(
+        {
+          status: 'passed',
+          format,
+          count: output.count,
+          pages,
+          verified,
+          bytes,
+          prepare_ms: Math.round(built - start),
+          heap_before: before,
+          heap_after: after,
+          heap_peak_sample: peak,
+          max_timer_gap_ms: Math.round(maxTickGap),
+          heap_note: 'Browser performance.memory is approximate; excludes Blob backing storage'
+        },
+        null,
+        2
+      )
+    } catch (error) {
+      result.textContent = JSON.stringify(
+        {
+          status: cancel && error.name === 'AbortError' ? 'cancelled' : 'failed',
+          error: error.name,
+          count,
+          pages,
+          cancel_latency_ms: cancelAt ? Math.round(performance.now() - cancelAt) : null,
+          partial_download: false
+        },
+        null,
+        2
+      )
+    } finally {
+      clearInterval(timer)
+      document.querySelectorAll('button').forEach(b => (b.disabled = false))
+    }
+  }
+  document.querySelector('#csv').onclick = () => run('csv')
+  document.querySelector('#json').onclick = () => run('json')
+  document.querySelector('#cancelTest').onclick = () => run('csv', true)
 </script>

--- a/apps/slax-reader-dweb/tests/unit/components/BookmarkList/BookmarksEmptyState.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/BookmarkList/BookmarksEmptyState.spec.ts
@@ -1,8 +1,15 @@
 // BookmarksEmptyState 组件单测
 import BookmarksEmptyState from '~~/layers/core/app/components/BookmarkList/BookmarksEmptyState.vue'
 
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { mountWithApp } from '~~/tests/setup/mount'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { mockAnalyticsLog } = vi.hoisted(() => ({
+  mockAnalyticsLog: vi.fn()
+}))
+
+mockNuxtImport('analyticsLog', () => mockAnalyticsLog)
 
 const baseProps = {
   filterStatus: 'inbox',
@@ -12,6 +19,7 @@ const baseProps = {
 describe('BookmarksEmptyState', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    mockAnalyticsLog.mockReset()
   })
 
   describe('inbox：B/C/null', () => {
@@ -30,11 +38,18 @@ describe('BookmarksEmptyState', () => {
       expect(iconSvg.find('circle').exists()).toBe(false)
     })
 
-    it('inboxState=B：点击安装按钮 → window.open(pluginUrl)', async () => {
+    it('inboxState=B：点击安装按钮 → analyticsLog + window.open(pluginUrl)', async () => {
       const mockOpen = vi.fn()
       vi.stubGlobal('open', mockOpen)
       const wrapper = mountWithApp(BookmarksEmptyState, { props: { ...baseProps, inboxState: 'B' } })
       await wrapper.find('.empty-view-action').trigger('click')
+      expect(mockAnalyticsLog).toHaveBeenCalledWith({
+        event: 'bookmark_list_download',
+        client: 'browser_extension'
+      })
+      expect(mockAnalyticsLog).toHaveBeenCalledTimes(1)
+      expect(mockOpen).toHaveBeenCalledTimes(1)
+      expect(mockAnalyticsLog.mock.invocationCallOrder[0]!).toBeLessThan(mockOpen.mock.invocationCallOrder[0]!)
       expect(mockOpen).toHaveBeenCalledWith(expect.stringContaining('chromewebstore.google.com'))
     })
 

--- a/apps/slax-reader-dweb/tests/unit/components/BookmarkTags.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/BookmarkTags.spec.ts
@@ -11,7 +11,7 @@ import BookmarkTags from '~~/layers/core/app/components/BookmarkTags.vue'
 
 import type { BookmarkTag } from '@commons/types/interface'
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
-import { flushPromises } from '@vue/test-utils'
+import { DOMWrapper, flushPromises } from '@vue/test-utils'
 import { LocalFirstAdapterKey, SharedUserTagsKey } from '~~/layers/core/app/composables/local-first/injection'
 import { mountWithApp } from '~~/tests/setup/mount'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -52,18 +52,31 @@ function mountTags(options: Parameters<typeof mountWithApp>[1]) {
   return wrapper
 }
 
-function isPanelHidden(wrapper: Wrapper): boolean {
-  const el = wrapper.find('.search-list')
-  if (!el.exists()) return true
-  return (el.element as HTMLElement).style.display === 'none'
+// 面板现在 Teleport 到 document.body，不再挂在 wrapper 的子树里，
+// 需要直接查 document 而非 wrapper.find/findAll；包一层 DOMWrapper 保留 .trigger() 用法
+function isPanelHidden(): boolean {
+  const el = document.querySelector<HTMLElement>('.search-list')
+  if (!el) return true
+  return el.style.display === 'none'
 }
 
-function candidateNames(wrapper: Wrapper): string[] {
-  return wrapper.findAll('.search-tag:not(.create)').map(row => row.find('.tag-name').text())
+function candidateNames(): string[] {
+  return Array.from(document.querySelectorAll<HTMLElement>('.search-tag:not(.create) .tag-name')).map(el => el.textContent ?? '')
 }
 
-function selectable(wrapper: Wrapper) {
-  return wrapper.findAll('.search-tag:not(.attached):not(.create)')
+function selectable(): DOMWrapper<HTMLElement>[] {
+  return Array.from(document.querySelectorAll<HTMLElement>('.search-tag:not(.attached):not(.create)')).map(el => new DOMWrapper(el))
+}
+
+// 面板内其它元素（confirm-btn / input / result-wrapper / group-heading / search-tag.*）同理，需查 document
+function panelFind(selector: string): DOMWrapper<HTMLElement> {
+  const el = document.querySelector<HTMLElement>(selector)
+  if (!el) throw new Error(`panelFind: no element matches ${selector}`)
+  return new DOMWrapper(el)
+}
+
+function panelFindAll(selector: string): DOMWrapper<HTMLElement>[] {
+  return Array.from(document.querySelectorAll<HTMLElement>(selector)).map(el => new DOMWrapper(el))
 }
 
 async function openPanel(wrapper: Wrapper) {
@@ -167,26 +180,26 @@ describe('components/BookmarkTags', () => {
     it('候选分组：mine 标题在前、auto 在后；已绑定的显示但不可选', async () => {
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      const headings = wrapper.findAll('.group-heading').map(h => h.text())
+      const headings = panelFindAll('.group-heading').map(h => h.text())
       expect(headings).toEqual(['My tags', 'Auto tags'])
-      expect(candidateNames(wrapper)).toEqual(['tech', 'design', 'ai', 'ai-tools'])
-      expect(wrapper.findAll('.search-tag.attached').map(r => r.find('.tag-name').text())).toEqual(['tech', 'ai'])
-      await wrapper.find('.search-tag.attached').trigger('click')
-      expect(wrapper.find('.confirm-btn').text()).toBe('Done (0)')
+      expect(candidateNames()).toEqual(['tech', 'design', 'ai', 'ai-tools'])
+      expect(panelFindAll('.search-tag.attached').map(r => r.find('.tag-name').text())).toEqual(['tech', 'ai'])
+      await panelFind('.search-tag.attached').trigger('click')
+      expect(panelFind('.confirm-btn').text()).toBe('Done (0)')
     })
 
     it('某组为空时不渲染该组标题', async () => {
       mockGet.mockResolvedValue([design])
       const wrapper = mountTags({ props: { tags: [], bookmarkId: 7 } })
       await openPanel(wrapper)
-      expect(wrapper.findAll('.group-heading').map(h => h.text())).toEqual(['My tags'])
+      expect(panelFindAll('.group-heading').map(h => h.text())).toEqual(['My tags'])
     })
 
     it('searchText 过滤名称包含 ai 的候选', async () => {
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      await wrapper.find('input').setValue('ai')
-      expect(candidateNames(wrapper)).toEqual(['ai', 'ai-tools'])
+      await panelFind('input').setValue('ai')
+      expect(candidateNames()).toEqual(['ai', 'ai-tools'])
     })
 
     it('isAddingLoading：searchingTags 调用中再次触发返回早返', async () => {
@@ -208,45 +221,45 @@ describe('components/BookmarkTags', () => {
     it('多次点击 add 切换面板', async () => {
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      expect(isPanelHidden(wrapper)).toBe(false)
+      expect(isPanelHidden()).toBe(false)
       await openPanel(wrapper)
-      expect(isPanelHidden(wrapper)).toBe(true)
+      expect(isPanelHidden()).toBe(true)
     })
 
     it('挂到 document 上：+ 能关掉开着的面板，且不重复拉词表', async () => {
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 }, attachTo: document.body })
       await openPanel(wrapper)
-      expect(isPanelHidden(wrapper)).toBe(false)
+      expect(isPanelHidden()).toBe(false)
       // vueuse 的 click-outside 挂在 window 的 capture 阶段，靠 setTimeout(0) 去抖
       wrapper.find('.tag-add-wrap .tag-add').element.dispatchEvent(new MouseEvent('click', { bubbles: true }))
       await new Promise(resolve => setTimeout(resolve, 0))
       await flushPromises()
-      expect(isPanelHidden(wrapper)).toBe(true)
+      expect(isPanelHidden()).toBe(true)
       expect(mockGet).toHaveBeenCalledTimes(1)
     })
 
     it('搜索词改了，之前勾的“创建 xxx”从 pending 里去掉', async () => {
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      await wrapper.find('input').setValue('foo')
-      await wrapper.find('.search-tag.create').trigger('click')
-      expect(wrapper.find('.confirm-btn').text()).toContain('1')
-      await wrapper.find('input').setValue('foob')
-      expect(wrapper.find('.confirm-btn').text()).toContain('0')
+      await panelFind('input').setValue('foo')
+      await panelFind('.search-tag.create').trigger('click')
+      expect(panelFind('.confirm-btn').text()).toContain('1')
+      await panelFind('input').setValue('foob')
+      expect(panelFind('.confirm-btn').text()).toContain('0')
     })
 
     it('重开面板保留 searchText 与滚动位置', async () => {
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      await wrapper.find('input').setValue('des')
-      const list = wrapper.find('.result-wrapper')
+      await panelFind('input').setValue('des')
+      const list = panelFind('.result-wrapper')
       Object.defineProperty(list.element, 'scrollTop', { value: 42, writable: true, configurable: true })
       await list.trigger('scroll')
       await openPanel(wrapper) // close
       await openPanel(wrapper) // reopen
-      expect((wrapper.find('input').element as HTMLInputElement).value).toBe('des')
-      expect(candidateNames(wrapper)).toEqual(['design'])
-      expect((wrapper.find('.result-wrapper').element as HTMLElement).scrollTop).toBe(42)
+      expect((panelFind('input').element as HTMLInputElement).value).toBe('des')
+      expect(candidateNames()).toEqual(['design'])
+      expect((panelFind('.result-wrapper').element as HTMLElement).scrollTop).toBe(42)
     })
   })
 
@@ -254,14 +267,14 @@ describe('components/BookmarkTags', () => {
     it('点击候选只切换 pending，不发请求；再点取消', async () => {
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      const rows = selectable(wrapper)
+      const rows = selectable()
       await rows[0]!.trigger('click')
       expect(mockPost).not.toHaveBeenCalled()
-      expect(selectable(wrapper)[0]!.classes()).toContain('active')
-      expect(wrapper.find('.confirm-btn').text()).toBe('Done (1)')
-      await selectable(wrapper)[0]!.trigger('click')
-      expect(selectable(wrapper)[0]!.classes()).not.toContain('active')
-      expect(wrapper.find('.confirm-btn').text()).toBe('Done (0)')
+      expect(selectable()[0]!.classes()).toContain('active')
+      expect(panelFind('.confirm-btn').text()).toBe('Done (1)')
+      await selectable()[0]!.trigger('click')
+      expect(selectable()[0]!.classes()).not.toContain('active')
+      expect(panelFind('.confirm-btn').text()).toBe('Done (0)')
     })
 
     it('Done：一次 ADD_BOOKMARK_TAGS 带 tags:[{id},{id}]，合并列表 + emit change + 关闭', async () => {
@@ -271,9 +284,9 @@ describe('components/BookmarkTags', () => {
       ])
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      await selectable(wrapper)[0]!.trigger('click')
-      await selectable(wrapper)[1]!.trigger('click')
-      await wrapper.find('.confirm-btn').trigger('click')
+      await selectable()[0]!.trigger('click')
+      await selectable()[1]!.trigger('click')
+      await panelFind('.confirm-btn').trigger('click')
       await flushPromises()
       expect(mockPost).toHaveBeenCalledTimes(1)
       const call = lastPostBody()
@@ -282,23 +295,23 @@ describe('components/BookmarkTags', () => {
       expect(wrapper.findAll('.tags-cells .tag-chip')).toHaveLength(4)
       const emitted = wrapper.emitted('change')![0]![0] as BookmarkTag[]
       expect(emitted.map(t => t.id)).toEqual([1, 2, 3, 4])
-      expect(isPanelHidden(wrapper)).toBe(true)
+      expect(isPanelHidden()).toBe(true)
     })
 
     it('Done 时 pending 为空：只关闭，不发请求', async () => {
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      await wrapper.find('.confirm-btn').trigger('click')
+      await panelFind('.confirm-btn').trigger('click')
       await flushPromises()
       expect(mockPost).not.toHaveBeenCalled()
-      expect(isPanelHidden(wrapper)).toBe(true)
+      expect(isPanelHidden()).toBe(true)
     })
 
     it('bookmarkId 与 bookmarkUid 都缺失：不发请求', async () => {
       const wrapper = mountTags({ props: { tags: [...baseTags] } })
       await openPanel(wrapper)
-      await selectable(wrapper)[0]!.trigger('click')
-      await wrapper.find('.confirm-btn').trigger('click')
+      await selectable()[0]!.trigger('click')
+      await panelFind('.confirm-btn').trigger('click')
       await flushPromises()
       expect(mockPost).not.toHaveBeenCalled()
     })
@@ -307,8 +320,8 @@ describe('components/BookmarkTags', () => {
       mockPost.mockResolvedValueOnce([design])
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkUid: 'u1' } })
       await openPanel(wrapper)
-      await selectable(wrapper)[0]!.trigger('click')
-      await wrapper.find('.confirm-btn').trigger('click')
+      await selectable()[0]!.trigger('click')
+      await panelFind('.confirm-btn').trigger('click')
       await flushPromises()
       expect(lastPostBody().body).toEqual({ bookmark_id: undefined, bookmark_uid: 'u1', tags: [{ id: 3 }] })
     })
@@ -317,41 +330,41 @@ describe('components/BookmarkTags', () => {
       mockPost.mockResolvedValueOnce([{ id: 99, name: 'brand-new', show_name: 'brand-new', source: 'mine', added_by: 'user' }])
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      await wrapper.find('input').setValue('brand-new')
-      const create = wrapper.find('.search-tag.create')
+      await panelFind('input').setValue('brand-new')
+      const create = panelFind('.search-tag.create')
       expect(create.exists()).toBe(true)
       expect(create.text()).toContain('Create “brand-new”')
       await create.trigger('click')
-      expect(wrapper.find('.confirm-btn').text()).toBe('Done (1)')
-      await wrapper.find('.confirm-btn').trigger('click')
+      expect(panelFind('.confirm-btn').text()).toBe('Done (1)')
+      await panelFind('.confirm-btn').trigger('click')
       await flushPromises()
       expect(lastPostBody().body.tags).toEqual([{ name: 'brand-new' }])
       expect(wrapper.findAll('.tags-cells .tag-chip')).toHaveLength(3)
       // 提交成功后清空 searchText
       await openPanel(wrapper)
-      expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
+      expect((panelFind('input').element as HTMLInputElement).value).toBe('')
     })
 
     it('搜索精确匹配某候选（大小写敏感）：不出现 create 行', async () => {
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      await wrapper.find('input').setValue('design')
-      expect(wrapper.find('.search-tag.create').exists()).toBe(false)
-      await wrapper.find('input').setValue('Design')
-      expect(wrapper.find('.search-tag.create').exists()).toBe(true)
+      await panelFind('input').setValue('design')
+      expect(document.querySelector('.search-tag.create')).toBeNull()
+      await panelFind('input').setValue('Design')
+      expect(document.querySelector('.search-tag.create')).not.toBeNull()
     })
 
     it('出错：toast 报错、pending 保留、面板不关', async () => {
       mockPost.mockRejectedValueOnce(new Error('boom'))
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      await selectable(wrapper)[0]!.trigger('click')
-      await wrapper.find('.confirm-btn').trigger('click')
+      await selectable()[0]!.trigger('click')
+      await panelFind('.confirm-btn').trigger('click')
       await flushPromises()
       expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }))
-      expect(isPanelHidden(wrapper)).toBe(false)
-      expect(wrapper.find('.confirm-btn').text()).toBe('Done (1)')
-      expect(selectable(wrapper)[0]!.classes()).toContain('active')
+      expect(isPanelHidden()).toBe(false)
+      expect(panelFind('.confirm-btn').text()).toBe('Done (1)')
+      expect(selectable()[0]!.classes()).toContain('active')
       expect(wrapper.emitted('change')).toBeUndefined()
     })
   })
@@ -360,33 +373,33 @@ describe('components/BookmarkTags', () => {
     it('文本是已绑定的 tag 名：直接关闭不调 post', async () => {
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      const input = wrapper.find('input')
+      const input = panelFind('input')
       await input.setValue('tech')
       await input.trigger('keydown', { key: 'Enter' })
       await flushPromises()
       expect(mockPost).not.toHaveBeenCalled()
-      expect(isPanelHidden(wrapper)).toBe(true)
+      expect(isPanelHidden()).toBe(true)
     })
 
     it('文本精确命中候选：加入 pending 并提交 {id}', async () => {
       mockPost.mockResolvedValueOnce([design])
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      const input = wrapper.find('input')
+      const input = panelFind('input')
       await input.setValue('design')
       await input.trigger('keydown', { key: 'Enter' })
       await flushPromises()
       expect(mockPost).toHaveBeenCalledTimes(1)
       expect(lastPostBody().body.tags).toEqual([{ id: 3 }])
-      expect(isPanelHidden(wrapper)).toBe(true)
+      expect(isPanelHidden()).toBe(true)
     })
 
     it('文本未命中：提交 {name}，连同已勾选的候选', async () => {
       mockPost.mockResolvedValueOnce([aiTools, { id: 99, name: 'brand-new-tag', show_name: 'brand-new-tag' }])
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      await selectable(wrapper)[1]!.trigger('click')
-      const input = wrapper.find('input')
+      await selectable()[1]!.trigger('click')
+      const input = panelFind('input')
       await input.setValue('brand-new-tag')
       await input.trigger('keydown', { key: 'Enter' })
       await flushPromises()
@@ -396,7 +409,7 @@ describe('components/BookmarkTags', () => {
     it('面板已关闭：Enter 不调 post', async () => {
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 } })
       await openPanel(wrapper)
-      const input = wrapper.find('input')
+      const input = panelFind('input')
       await input.setValue('design')
       await openPanel(wrapper) // close
       await input.trigger('keydown', { key: 'Enter' })
@@ -410,14 +423,14 @@ describe('components/BookmarkTags', () => {
       mockPost.mockResolvedValueOnce([design])
       const wrapper = mountTags({ props: { tags: [...baseTags], bookmarkId: 7 }, attachTo: document.body })
       await openPanel(wrapper)
-      await selectable(wrapper)[0]!.trigger('click')
+      await selectable()[0]!.trigger('click')
       await tick() // vueuse onClickOutside 用 setTimeout(0) 去重连点
       document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
       await flushPromises()
       await tick()
       expect(mockPost).toHaveBeenCalledTimes(1)
       expect(lastPostBody().url).toBe('/v1/bookmark/add_tags')
-      expect(isPanelHidden(wrapper)).toBe(true)
+      expect(isPanelHidden()).toBe(true)
     })
   })
 
@@ -454,12 +467,12 @@ describe('components/BookmarkTags', () => {
       expect(bookmarkTagSource).toHaveBeenCalledTimes(1)
       await openPanel(wrapper)
       expect(mockGet).not.toHaveBeenCalled()
-      expect(candidateNames(wrapper)).toEqual(['tech', 'design', 'ai-tools'])
-      await selectable(wrapper)[0]!.trigger('click')
-      await selectable(wrapper)[1]!.trigger('click')
-      await wrapper.find('input').setValue('fresh')
-      await wrapper.find('.search-tag.create').trigger('click')
-      await wrapper.find('.confirm-btn').trigger('click')
+      expect(candidateNames()).toEqual(['tech', 'design', 'ai-tools'])
+      await selectable()[0]!.trigger('click')
+      await selectable()[1]!.trigger('click')
+      await panelFind('input').setValue('fresh')
+      await panelFind('.search-tag.create').trigger('click')
+      await panelFind('.confirm-btn').trigger('click')
       await flushPromises()
       expect(src.createUserTag).toHaveBeenCalledTimes(1)
       expect(src.createUserTag).toHaveBeenCalledWith('fresh')
@@ -469,7 +482,7 @@ describe('components/BookmarkTags', () => {
       expect(mockPost).not.toHaveBeenCalled()
       const emitted = wrapper.emitted('change')![0]![0] as BookmarkTag[]
       expect(emitted.map(t => t.id)).toEqual(['t-1', 't-3', 't-4', 't-new'])
-      expect(isPanelHidden(wrapper)).toBe(true)
+      expect(isPanelHidden()).toBe(true)
     })
 
     it('非 compact：源没有 setTags 时逐个 add', async () => {
@@ -482,9 +495,9 @@ describe('components/BookmarkTags', () => {
       })
       await flushPromises()
       await openPanel(wrapper)
-      await selectable(wrapper)[0]!.trigger('click')
-      await selectable(wrapper)[1]!.trigger('click')
-      await wrapper.find('.confirm-btn').trigger('click')
+      await selectable()[0]!.trigger('click')
+      await selectable()[1]!.trigger('click')
+      await panelFind('.confirm-btn').trigger('click')
       await flushPromises()
       expect(src.add).toHaveBeenCalledTimes(2)
       expect(src.add).toHaveBeenNthCalledWith(1, 'b-1', 't-3')
@@ -527,11 +540,11 @@ describe('components/BookmarkTags', () => {
       expect(bookmarkTagSource).not.toHaveBeenCalled()
       await openPanel(wrapper)
       expect(mockGet).not.toHaveBeenCalled()
-      expect(candidateNames(wrapper)).toEqual(['tech', 'design', 'ai-tools'])
-      await selectable(wrapper)[0]!.trigger('click')
-      await wrapper.find('input').setValue('fresh')
-      await wrapper.find('.search-tag.create').trigger('click')
-      await wrapper.find('.confirm-btn').trigger('click')
+      expect(candidateNames()).toEqual(['tech', 'design', 'ai-tools'])
+      await selectable()[0]!.trigger('click')
+      await panelFind('input').setValue('fresh')
+      await panelFind('.search-tag.create').trigger('click')
+      await panelFind('.confirm-btn').trigger('click')
       await flushPromises()
       expect(actions.createUserTag).toHaveBeenCalledWith('fresh')
       expect(actions.setTags).toHaveBeenCalledTimes(1)
@@ -560,7 +573,7 @@ describe('components/BookmarkTags', () => {
       })
       await openPanel(wrapper)
       expect(mockGet).toHaveBeenCalledTimes(1)
-      expect(candidateNames(wrapper)).toEqual(['tech', 'design', 'ai', 'ai-tools'])
+      expect(candidateNames()).toEqual(['tech', 'design', 'ai', 'ai-tools'])
     })
 
     it('LF 出错：toast + pending 保留', async () => {
@@ -572,12 +585,12 @@ describe('components/BookmarkTags', () => {
       })
       await flushPromises()
       await openPanel(wrapper)
-      await selectable(wrapper)[0]!.trigger('click')
-      await wrapper.find('.confirm-btn').trigger('click')
+      await selectable()[0]!.trigger('click')
+      await panelFind('.confirm-btn').trigger('click')
       await flushPromises()
       expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }))
-      expect(isPanelHidden(wrapper)).toBe(false)
-      expect(wrapper.find('.confirm-btn').text()).toBe('Done (1)')
+      expect(isPanelHidden()).toBe(false)
+      expect(panelFind('.confirm-btn').text()).toBe('Done (1)')
     })
   })
 })


### PR DESCRIPTION
## Bug
In the inbox list, clicking "+" on a bookmark's tag row opens a tag-add popup. The popup was visually clipped/covered by the bookmark cell below it in the list.

## Root cause
The popup (`.search-list` in `BookmarkTags.vue`) rendered inline inside `.bookmark-tags` → `.article-tags` → the `virtua` virtual-scroll item wrapper for that card. `virtua` gives each item wrapper `contain: layout style`, which creates its own stacking context — so no `z-index` set inside a card can ever paint above the *next* card's wrapper, since that's a sibling stacking context that comes later in DOM/paint order.

A prior fix attempt exists in `BookmarkCell.vue`:
```scss
&:has(.search-list) {
  z-index: 5;
}
```
This doesn't work for exactly the reason above — the containment traps it. Removed as dead code.

## Fix
- Teleport the popup to `<body>`, switching its positioning from offset-relative-to-`.bookmark-tags` to `position: fixed` computed from the "+" button's `getBoundingClientRect()`.
- Reposition on `window` `scroll`/`resize` while the panel is open, since the trigger button can move under a scrollable list/sidebar while the popup stays open.
- This matches the existing codebase convention for escaping stacking contexts (`Teleport to="body"` + `position: fixed`, e.g. `Dashboard/DatePicker.vue`).

## Testing
- Updated `BookmarkTags.spec.ts`: since the popup no longer lives inside the mounted wrapper's subtree, panel-related lookups now query `document` directly via new `panelFind`/`panelFindAll` helpers (wrapping raw elements in `DOMWrapper`) instead of `wrapper.find`/`findAll`.
- `pnpm exec vitest run tests/unit/components/BookmarkTags.spec.ts tests/unit/components/BookmarkList/BookmarkCell.spec.ts` — 72/72 passing.
- `pnpm exec nuxt build` (both upstream and fork) — succeeds.