### PR TITLE
🐛 标签面板被下方卡片压住，无法点击

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkCell.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkCell.vue
@@ -549,7 +549,9 @@ const starBookmark = async (isStar: boolean) => {
   align-items: flex-start;
   gap: 16px;
 
-  // 标签面板开着时抬高整卡，不被下一张卡的 body 压住
+  // 标签面板开着时抬高整卡，不被下一张卡的 body 压住。
+  // 虚拟列表里 item 外层有 contain: layout 的层叠上下文，
+  // 这条只在卡片直接相邻时生效，列表里靠 BookmarkListContent 抬 item
   &:has(.search-list) {
     z-index: 5;
   }

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkListContent.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarkListContent.vue
@@ -128,6 +128,13 @@ const emit = defineEmits<{
 .bookmarks {
   --style: relative;
 
+  // 虚拟列表给每个 item 套了一层 contain: layout style 的 div，
+  // layout containment 自带层叠上下文，卡片自己的 z-index 抬不过后面的 item。
+  // 标签面板开着时抬 item 本身，面板才能盖住下面的卡片
+  :deep(div:has(> .article-card .search-list)) {
+    z-index: 5;
+  }
+
   .card-cells-wrapper {
     --style: px-16px;
     display: flex;


### PR DESCRIPTION
## 问题

列表里点某张卡片的「+」加标签，面板会渲染在下方几张卡片之下，点不到。

## 原因

卡片上已经有 `.article-card:has(.search-list) { z-index: 5 }`，线上构建也带着这条规则。它不起作用是因为列表走了 virtua 的 `WindowVirtualizer`，每个 item 外面套了一层 `contain: layout style` 的 div。layout containment 会生成层叠上下文，卡片的 z-index 只在自己的 item 里有效，后面的 item 按 DOM 顺序画在上面。

## 修复

在 `BookmarkListContent.vue` 里，面板打开时抬 item 本身：

```scss
:deep(div:has(> .article-card .search-list)) { z-index: 5; }
```

卡片上的原规则保留，给非虚拟列表的 fallback 用；注释改成说明实际情况。

## 验证

- 用同样的结构（`contain: layout style` 的 item + 卡片 + 面板）在 headless Chrome 里做了最小复现：修复前 `elementFromPoint` 落在第二张卡的标签行，修复后落在面板上。
- `@vue/compiler-sfc` 编译结果：`.bookmarks[data-v-x] div:has(> .article-card .search-list)`。
- eslint / prettier 通过。
- `tests/unit/components/BookmarkTags.spec.ts` 与 `BookmarkList/` 下的用例：190 通过。`BookmarksEmptyState.spec.ts` 在 main 上就挂在 `@/utils/analytics` 的路径解析（#282 引入），与本改动无关。

## 后续

合并后需要在 unnoo/slax_reader_frontend 的 develop 上把 `upstream` 子模块指到新的 main，r.slax.dev 才会更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BfjDnY5W2Jbkh6i4atg31
