### PR TITLE
✨ Update E-ink link indicator

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/ArticleCommentInput.ce.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/ArticleCommentInput.ce.vue
@@ -84,10 +84,16 @@ const onKeyDown = (e: KeyboardEvent) => {
     }
 
     const textareaTarget = e.target as HTMLTextAreaElement
+    // Shift+Enter 交给原生换行
+    // 避免 nextTick 抢跑光标
+    if (e.shiftKey) {
+      nextTick(handleInput)
+      return
+    }
     const cursorPosition = textareaTarget.selectionStart
     const textBeforeCursor = inputText.value.slice(0, cursorPosition)
     const textAfterCursor = inputText.value.slice(cursorPosition)
-    !e.shiftKey && (inputText.value = textBeforeCursor + '\n' + textAfterCursor)
+    inputText.value = textBeforeCursor + '\n' + textAfterCursor
 
     nextTick(() => {
       textareaTarget.selectionStart = cursorPosition + 1

--- a/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/ArticleSelectionPanel.ce.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Article/Selection/ArticleSelectionPanel.ce.vue
@@ -312,10 +312,16 @@ const onKeyDown = (e: KeyboardEvent) => {
     }
 
     const textareaTarget = e.target as HTMLTextAreaElement
+    // Shift+Enter 交给原生换行
+    // 避免 nextTick 抢跑光标
+    if (e.shiftKey) {
+      nextTick(handleInput)
+      return
+    }
     const cursorPosition = textareaTarget.selectionStart
     const textBeforeCursor = inputText.value.slice(0, cursorPosition)
     const textAfterCursor = inputText.value.slice(cursorPosition)
-    !e.shiftKey && (inputText.value = textBeforeCursor + '\n' + textAfterCursor)
+    inputText.value = textBeforeCursor + '\n' + textAfterCursor
 
     nextTick(() => {
       textareaTarget.selectionStart = cursorPosition + 1

--- a/apps/slax-reader-dweb/layers/core/app/components/Markdown/MarkdownText.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Markdown/MarkdownText.vue
@@ -137,12 +137,12 @@ const handleAnchors = () => {
       color: var(--slax-link);
     }
 
-    // 真实外链：E-ink 加 🔗 前缀
+    // 真实外链：E-ink 加 ↗︎ 后缀
     &:deep(a:not(.slax_link)) {
       color: var(--slax-link);
 
-      &::before {
-        content: var(--slax-link-prefix, '');
+      &::after {
+        content: var(--slax-link-suffix, '');
       }
     }
 

--- a/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotChatPanel.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotChatPanel.vue
@@ -1141,12 +1141,12 @@ defineExpose({ addQuoteData, focusTextarea })
         font-family: var(--slax-font-mono);
       }
 
-      // 日夜强调色，E-ink 蓝 + 🔗
+      // 日夜强调色，E-ink 蓝 + ↗︎
       :deep(a) {
         color: var(--slax-link);
 
-        &::before {
-          content: var(--slax-link-prefix, '');
+        &::after {
+          content: var(--slax-link-suffix, '');
         }
       }
 

--- a/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotChatPanel.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Snapshot/SnapshotChatPanel.vue
@@ -694,10 +694,16 @@ const onKeyDown = (e: KeyboardEvent) => {
       return
     }
     const textareaTarget = e.target as HTMLTextAreaElement
+    // Shift+Enter 交给原生换行
+    // 避免 nextTick 抢跑光标
+    if (e.shiftKey) {
+      nextTick(handleInput)
+      return
+    }
     const cursorPosition = textareaTarget.selectionStart
     const textBeforeCursor = inputText.value.slice(0, cursorPosition)
     const textAfterCursor = inputText.value.slice(cursorPosition)
-    !e.shiftKey && (inputText.value = textBeforeCursor + '\n' + textAfterCursor)
+    inputText.value = textBeforeCursor + '\n' + textAfterCursor
     nextTick(() => {
       textareaTarget.selectionStart = cursorPosition + 1
       textareaTarget.selectionEnd = cursorPosition + 1

--- a/apps/slax-reader-dweb/layers/core/styles/article/_content-mixin.scss
+++ b/apps/slax-reader-dweb/layers/core/styles/article/_content-mixin.scss
@@ -150,13 +150,13 @@
     border-bottom-right-radius: var(--slax-radius-sm);
   }
 
-  /* 链接：日夜强调色，E-ink 蓝 + 🔗 */
+  /* 链接：日夜强调色，E-ink 蓝 + ↗︎ */
   a {
     --style: underline-none border-none decoration-none cursor-pointer;
     color: var(--slax-link);
 
-    &::before {
-      content: var(--slax-link-prefix, '');
+    &::after {
+      content: var(--slax-link-suffix, '');
     }
   }
 

--- a/apps/slax-reader-dweb/layers/core/styles/theme.tokens.css
+++ b/apps/slax-reader-dweb/layers/core/styles/theme.tokens.css
@@ -26,7 +26,7 @@
 
   /* 链接色：日夜随强调色，E-ink 见下方 */
   --slax-link: var(--slax-accent);
-  --slax-link-prefix: '';
+  --slax-link-suffix: '';
 
   /* 颜色 - 功能 */
   --slax-danger: #c44;
@@ -173,9 +173,9 @@
   --slax-accent-soft: #666666;
   --slax-accent-bg: #f0f0f0;
 
-  /* E-ink 链接用经典蓝 + 🔗 前缀 */
+  /* E-ink 链接用经典蓝 + ↗︎ 后缀 */
   --slax-link: #5490c2;
-  --slax-link-prefix: '🔗 ';
+  --slax-link-suffix: ' ↗︎';
 
   --slax-danger: #444444;
   --slax-danger-bg: #eeeeee;

--- a/apps/slax-reader-dweb/tests/fixtures/20260908-bookmark-export-browser.html
+++ b/apps/slax-reader-dweb/tests/fixtures/20260908-bookmark-export-browser.html
@@ -1,29 +1,175 @@
 <!doctype html>
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>Saved-link export browser validation</title>
-<style>body{font:16px system-ui;max-width:900px;margin:40px auto}button{padding:12px;margin:8px}pre{white-space:pre-wrap}</style>
+<style>
+  body {
+    font: 16px system-ui;
+    max-width: 900px;
+    margin: 40px auto;
+  }
+  button {
+    padding: 12px;
+    margin: 8px;
+  }
+  pre {
+    white-space: pre-wrap;
+  }
+</style>
 <h1>Saved-link export browser validation</h1>
 <p>Synthetic data only. Each run exports 100,000 links in 200 pages through the production export utility.</p>
 <button id="csv">Run CSV</button><button id="json">Run JSON</button><button id="cancelTest">Test cancellation</button>
-<p id="progress">Ready</p><pre id="result"></pre>
+<p id="progress">Ready</p>
+<pre id="result"></pre>
 <script type="module">
-import {prepareBookmarkExport} from './export.js';
-const progress=document.querySelector('#progress'), result=document.querySelector('#result');
-const makeItem=i=>({url:`https://example.com/saved/${i}`,title:`${i%3?'文章':'=SUM(1,2)'} ${i}, "quoted"\nsecond line 🐈`,tags:[{name:'阅读, "标签"',source:'ai'},{name:'work\nnotes',source:'user'}],saved_at:'2026-09-08T00:00:00.000Z',is_read:i%2===0,is_archived:i%3===0,is_starred:i%5===0,type:i%7===0?'shortcut':'article'});
-function parseCsv(text){let rows=[],row=[],cell='',quote=false;for(let i=0;i<text.length;i++){let c=text[i];if(c==='"'){if(quote&&text[i+1]==='"'){cell+='"';i++}else quote=!quote}else if(c===','&&!quote){row.push(cell);cell=''}else if(c==='\n'&&!quote){row.push(cell.replace(/\r$/,''));rows.push(row);row=[];cell=''}else cell+=c}return rows}
-async function run(format,cancel=false){
- document.querySelectorAll('button').forEach(b=>b.disabled=true);result.textContent='';
- const controller=new AbortController();let pages=0,count=0,peak=0,cancelAt=0,maxTickGap=0,last=performance.now();
- const start=performance.now(),before=performance.memory?.usedJSHeapSize??null;
- const timer=setInterval(()=>{const now=performance.now();maxTickGap=Math.max(maxTickGap,now-last);last=now;peak=Math.max(peak,performance.memory?.usedJSHeapSize??0)},10);
- try {
-  const output=await prepareBookmarkExport({format,signal:controller.signal,fetchPage:async(cursor,signal)=>{signal.throwIfAborted();pages++;const from=Number(cursor||0);return {items:Array.from({length:500},(_,j)=>makeItem(from+j)),next_cursor:from+500<100000?String(from+500):null}},onProgress:n=>{count=n;progress.textContent=`Prepared ${n} links`;if(cancel&&n===10000){setTimeout(()=>{cancelAt=performance.now();controller.abort()},0)}}});
-  const built=performance.now(),after=performance.memory?.usedJSHeapSize??null;clearInterval(timer);
-  const bytes=output.blob.size;const text=await output.blob.text();let verified=0;
-  if(format==='json'){const obj=JSON.parse(text);if(obj.schema_version!==1||obj.items.length!==100000)throw Error('JSON count/version mismatch');for(let i=0;i<obj.items.length;i++){if(JSON.stringify(obj.items[i])!==JSON.stringify(makeItem(i)))throw Error(`JSON record mismatch ${i}`);verified++}}
-  else {const rows=parseCsv(text.replace(/^\uFEFF/,''));if(rows.length!==100001)throw Error(`CSV count mismatch ${rows.length}`);for(let i=0;i<100000;i++){const item=makeItem(i),row=rows[i+1];const expected=[item.url,item.title.startsWith('=')?"'"+item.title:item.title,JSON.stringify(item.tags.map(t=>t.name)),item.saved_at,String(item.is_read),String(item.is_archived),String(item.is_starred),item.type];if(JSON.stringify(row)!==JSON.stringify(expected))throw Error(`CSV mismatch ${i}`);verified++}}
-  result.textContent=JSON.stringify({status:'passed',format,count:output.count,pages,verified,bytes,prepare_ms:Math.round(built-start),heap_before:before,heap_after:after,heap_peak_sample:peak,max_timer_gap_ms:Math.round(maxTickGap),heap_note:'Browser performance.memory is approximate; excludes Blob backing storage'},null,2);
- }catch(error){result.textContent=JSON.stringify({status:cancel&&error.name==='AbortError'?'cancelled':'failed',error:error.name,count,pages,cancel_latency_ms:cancelAt?Math.round(performance.now()-cancelAt):null,partial_download:false},null,2)}finally{clearInterval(timer);document.querySelectorAll('button').forEach(b=>b.disabled=false)}
-}
-document.querySelector('#csv').onclick=()=>run('csv');document.querySelector('#json').onclick=()=>run('json');document.querySelector('#cancelTest').onclick=()=>run('csv',true);
+  import { prepareBookmarkExport } from './export.js'
+  const progress = document.querySelector('#progress'),
+    result = document.querySelector('#result')
+  const makeItem = i => ({
+    url: `https://example.com/saved/${i}`,
+    title: `${i % 3 ? '文章' : '=SUM(1,2)'} ${i}, "quoted"\nsecond line 🐈`,
+    tags: [
+      { name: '阅读, "标签"', source: 'ai' },
+      { name: 'work\nnotes', source: 'user' }
+    ],
+    saved_at: '2026-09-08T00:00:00.000Z',
+    is_read: i % 2 === 0,
+    is_archived: i % 3 === 0,
+    is_starred: i % 5 === 0,
+    type: i % 7 === 0 ? 'shortcut' : 'article'
+  })
+  function parseCsv(text) {
+    let rows = [],
+      row = [],
+      cell = '',
+      quote = false
+    for (let i = 0; i < text.length; i++) {
+      let c = text[i]
+      if (c === '"') {
+        if (quote && text[i + 1] === '"') {
+          cell += '"'
+          i++
+        } else quote = !quote
+      } else if (c === ',' && !quote) {
+        row.push(cell)
+        cell = ''
+      } else if (c === '\n' && !quote) {
+        row.push(cell.replace(/\r$/, ''))
+        rows.push(row)
+        row = []
+        cell = ''
+      } else cell += c
+    }
+    return rows
+  }
+  async function run(format, cancel = false) {
+    document.querySelectorAll('button').forEach(b => (b.disabled = true))
+    result.textContent = ''
+    const controller = new AbortController()
+    let pages = 0,
+      count = 0,
+      peak = 0,
+      cancelAt = 0,
+      maxTickGap = 0,
+      last = performance.now()
+    const start = performance.now(),
+      before = performance.memory?.usedJSHeapSize ?? null
+    const timer = setInterval(() => {
+      const now = performance.now()
+      maxTickGap = Math.max(maxTickGap, now - last)
+      last = now
+      peak = Math.max(peak, performance.memory?.usedJSHeapSize ?? 0)
+    }, 10)
+    try {
+      const output = await prepareBookmarkExport({
+        format,
+        signal: controller.signal,
+        fetchPage: async (cursor, signal) => {
+          signal.throwIfAborted()
+          pages++
+          const from = Number(cursor || 0)
+          return { items: Array.from({ length: 500 }, (_, j) => makeItem(from + j)), next_cursor: from + 500 < 100000 ? String(from + 500) : null }
+        },
+        onProgress: n => {
+          count = n
+          progress.textContent = `Prepared ${n} links`
+          if (cancel && n === 10000) {
+            setTimeout(() => {
+              cancelAt = performance.now()
+              controller.abort()
+            }, 0)
+          }
+        }
+      })
+      const built = performance.now(),
+        after = performance.memory?.usedJSHeapSize ?? null
+      clearInterval(timer)
+      const bytes = output.blob.size
+      const text = await output.blob.text()
+      let verified = 0
+      if (format === 'json') {
+        const obj = JSON.parse(text)
+        if (obj.schema_version !== 1 || obj.items.length !== 100000) throw Error('JSON count/version mismatch')
+        for (let i = 0; i < obj.items.length; i++) {
+          if (JSON.stringify(obj.items[i]) !== JSON.stringify(makeItem(i))) throw Error(`JSON record mismatch ${i}`)
+          verified++
+        }
+      } else {
+        const rows = parseCsv(text.replace(/^\uFEFF/, ''))
+        if (rows.length !== 100001) throw Error(`CSV count mismatch ${rows.length}`)
+        for (let i = 0; i < 100000; i++) {
+          const item = makeItem(i),
+            row = rows[i + 1]
+          const expected = [
+            item.url,
+            item.title.startsWith('=') ? "'" + item.title : item.title,
+            JSON.stringify(item.tags.map(t => t.name)),
+            item.saved_at,
+            String(item.is_read),
+            String(item.is_archived),
+            String(item.is_starred),
+            item.type
+          ]
+          if (JSON.stringify(row) !== JSON.stringify(expected)) throw Error(`CSV mismatch ${i}`)
+          verified++
+        }
+      }
+      result.textContent = JSON.stringify(
+        {
+          status: 'passed',
+          format,
+          count: output.count,
+          pages,
+          verified,
+          bytes,
+          prepare_ms: Math.round(built - start),
+          heap_before: before,
+          heap_after: after,
+          heap_peak_sample: peak,
+          max_timer_gap_ms: Math.round(maxTickGap),
+          heap_note: 'Browser performance.memory is approximate; excludes Blob backing storage'
+        },
+        null,
+        2
+      )
+    } catch (error) {
+      result.textContent = JSON.stringify(
+        {
+          status: cancel && error.name === 'AbortError' ? 'cancelled' : 'failed',
+          error: error.name,
+          count,
+          pages,
+          cancel_latency_ms: cancelAt ? Math.round(performance.now() - cancelAt) : null,
+          partial_download: false
+        },
+        null,
+        2
+      )
+    } finally {
+      clearInterval(timer)
+      document.querySelectorAll('button').forEach(b => (b.disabled = false))
+    }
+  }
+  document.querySelector('#csv').onclick = () => run('csv')
+  document.querySelector('#json').onclick = () => run('json')
+  document.querySelector('#cancelTest').onclick = () => run('csv', true)
 </script>

--- a/apps/slax-reader-dweb/tests/unit/components/Chat/SnapshotChatPanel.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/Chat/SnapshotChatPanel.spec.ts
@@ -242,6 +242,21 @@ describe('SnapshotChatPanel.vue', () => {
       await ta.trigger('keydown', { key: 'Enter' })
       expect(mockBotChat).not.toHaveBeenCalled()
     })
+    // Shift+Enter 不应移动光标
+    // happy-dom 不模拟原生插入换行
+    it('E3: Shift+Enter 不手动挪动光标', async () => {
+      const wrapper = mountPanel({ bookmarkId: 1 })
+      const ta = wrapper.find('textarea')
+      const el = ta.element as HTMLTextAreaElement
+      await ta.setValue('asdfghjkl')
+      el.selectionStart = 3
+      el.selectionEnd = 3
+      await ta.trigger('keydown', { key: 'Enter', shiftKey: true })
+      await nextTick()
+      expect(el.selectionStart).toBe(3)
+      expect(el.selectionEnd).toBe(3)
+      expect(el.value).toBe('asdfghjkl')
+    })
   })
 
   describe('F. SSE 回调 / buffer', () => {


### PR DESCRIPTION
## Summary
- E-ink 模式下链接指示符由前缀 🔗 改为后缀 ↗︎
- 对应变量重命名：`--slax-link-prefix` → `--slax-link-suffix`
- Light/Dark 主题链接渲染不受影响

## 背景
本改动最初在 `codex/eink-link-arrow-pr` 分支上完成（当时 base 落后于当前 main），对应 fork 侧 PR 因 submodule 指针冲突被关闭未合并。现基于最新 main cherry-pick 同一改动，无冲突。

## Test plan
- 全仓搜索确认 `--slax-link-suffix` 三处消费点（MarkdownText.vue / SnapshotChatPanel.vue / _content-mixin.scss）均已同步更新
- 未跑完整测试套件，需 CI 验证