### PR TITLE
设置页顶栏与标签 chip：复核修正

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksSearchBar.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksSearchBar.vue
@@ -53,6 +53,11 @@
 <script lang="ts" setup>
 import { vOnClickOutside } from '@vueuse/components'
 
+// The page's current search text; when it changes (a ?q= handoff, or "back" out of a search) the box follows
+const props = defineProps<{
+  searchText?: string
+}>()
+
 const emit = defineEmits<{
   search: [keyword: string]
 }>()
@@ -140,6 +145,13 @@ const clearKeyword = () => {
   keyword.value = ''
   emit('search', '')
 }
+
+watch(
+  () => props.searchText,
+  value => {
+    if (value !== undefined) keyword.value = value
+  }
+)
 
 onMounted(() => {
   loadHistory()

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksTopBar.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksTopBar.vue
@@ -4,8 +4,8 @@
     <div class="topbar-inner">
       <!-- 左侧：侧栏折叠按钮 + 品牌名 + 主题切换 -->
       <div class="topbar-left">
-        <!-- 折叠按钮：≤920px 侧栏本身隐藏或转为横条，按钮随之隐藏 -->
-        <button class="topbar-menu" :title="menuLabel" :aria-label="menuLabel" :aria-expanded="!collapsed" @click="toggle" type="button">
+        <!-- 折叠按钮：≤920px 侧栏本身隐藏或转为横条，按钮随之隐藏；没有侧栏的页面用 sidebar-toggle=false 去掉 -->
+        <button v-if="sidebarToggle" class="topbar-menu" :title="menuLabel" :aria-label="menuLabel" :aria-expanded="!collapsed" @click="toggle" type="button">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
             <path d="M4 6h16M4 12h16M4 18h16" />
           </svg>
@@ -19,7 +19,7 @@
 
       <!-- 右侧：搜索框 + 通知 + 用户菜单 -->
       <div class="topbar-right">
-        <BookmarksSearchBar @search="onSearch" />
+        <BookmarksSearchBar :search-text="searchText" @search="onSearch" />
         <UserNotification :icon-style="UserNotificationIconStyle.TINY" @checkAll="emit('checkAll')">
           <template #icon>
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="color: var(--slax-text-muted)">
@@ -40,6 +40,16 @@ import BookmarksUserMenu from '#layers/core/app/components/BookmarkList/Bookmark
 import UserNotification, { UserNotificationIconStyle } from '#layers/core/app/components/Notification/UserNotification.vue'
 
 import { useSidebarCollapsed } from '#layers/core/app/composables/bookmark/useSidebarCollapsed'
+
+withDefaults(
+  defineProps<{
+    // Current search text of the hosting page, mirrored into the search box
+    searchText?: string
+    // Pages without a sidebar (settings) hide the collapse button
+    sidebarToggle?: boolean
+  }>(),
+  { searchText: undefined, sidebarToggle: true }
+)
 
 const emit = defineEmits<{
   search: [keyword: string]

--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/TagChip.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/TagChip.vue
@@ -2,7 +2,7 @@
 <template>
   <span
     class="tag-chip"
-    :class="{ mine: tag.source === 'mine', active, compact, clickable: !!onClickListener }"
+    :class="{ mine: tag.source === 'mine', active, compact, clickable: !!onClickListener, 'has-acts': promotable || removable }"
     :title="tag.show_name"
     role="button"
     :tabindex="onClickListener ? 0 : -1"
@@ -12,7 +12,7 @@
     <span class="tag-name">{{ tag.show_name }}</span>
     <span v-if="typeof count === 'number'" class="tag-count">{{ count }}</span>
     <i v-if="aiMark" class="tag-ai" :title="$t('component.bookmark_tags.by_ai')">AI</i>
-    <!-- 操作按钮浮在右缘：悬停时 chip 宽度不变，列表不会跳动 -->
+    <!-- Actions sit in a gutter reserved on the right: the chip keeps its width on hover and nothing gets covered -->
     <span v-if="promotable || removable" class="tag-acts">
       <button v-if="promotable" class="tag-act promote" type="button" :title="$t('component.tags_header.promote')" @click.stop="emit('promote', tag)">↑</button>
       <button v-if="removable" class="tag-act remove" type="button" :title="$t('common.operate.delete')" @click.stop="emit('remove', tag)">×</button>
@@ -114,12 +114,22 @@ void props
     font-style: normal;
   }
 
-  // 绝对定位在右缘，不占布局宽度；遮住标签名尾部是预期的
+  // Chips with actions keep a gutter on the right at all times, so showing the buttons never changes the width
+  &.has-acts {
+    padding-right: 28px;
+  }
+
+  &.compact.has-acts {
+    padding-right: 24px;
+  }
+
+  // Hidden, not display:none, so the buttons stay reachable by keyboard
   .tag-acts {
-    display: none;
+    display: inline-flex;
+    visibility: hidden;
     position: absolute;
     top: 50%;
-    right: 4px;
+    right: 5px;
     transform: translateY(-50%);
     gap: 2px;
   }
@@ -146,7 +156,7 @@ void props
 
   &:hover .tag-acts,
   &:focus-within .tag-acts {
-    display: inline-flex;
+    visibility: visible;
   }
 }
 </style>

--- a/apps/slax-reader-dweb/layers/core/app/components/Layouts/BookmarksLayout.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/Layouts/BookmarksLayout.vue
@@ -4,7 +4,7 @@
     <div class="small-screen-trigger" ref="smallScreenTrigger"></div>
 
     <!-- 顶栏：固定定位，毛玻璃效果，自包含所有内容 -->
-    <BookmarksTopBar @search="emit('search', $event)" @feedback="emit('feedback')" @check-all="emit('checkAll')" />
+    <BookmarksTopBar :search-text="searchText" @search="emit('search', $event)" @feedback="emit('feedback')" @check-all="emit('checkAll')" />
 
     <!-- 主体：顶部留出 header 高度，sidebar + main 布局 -->
     <div class="layout">
@@ -26,6 +26,11 @@
 import BookmarksTopBar from '#layers/core/app/components/BookmarkList/BookmarksTopBar.vue'
 
 import { useSidebarCollapsed } from '#layers/core/app/composables/bookmark/useSidebarCollapsed'
+
+defineProps<{
+  // Current search text, mirrored into the top bar's search box
+  searchText?: string
+}>()
 
 const emit = defineEmits<{
   search: [keyword: string]

--- a/apps/slax-reader-dweb/layers/core/app/pages/bookmarks/index.vue
+++ b/apps/slax-reader-dweb/layers/core/app/pages/bookmarks/index.vue
@@ -13,7 +13,7 @@
     <!-- FAB：浮动添加按钮 -->
     <BookmarksFab @click="isShowTopModal = true" />
 
-    <BookmarksLayout ref="bookmarksLayout" @search="text => (searchText = text)" @feedback="feedbackClick" @check-all="showNotificationList">
+    <BookmarksLayout ref="bookmarksLayout" :search-text="searchText" @search="text => (searchText = text)" @feedback="feedbackClick" @check-all="showNotificationList">
       <template v-slot:sidebar-left>
         <TabsSidebar ref="tabsSidebar" :tabType="searchText ? '' : filterStatus" @change-tab="inboxClick" />
       </template>
@@ -260,16 +260,18 @@ watch(filterStatus, (value, oldValue) => {
   reloadList()
 })
 
-// 其他页面（如设置页顶栏）带 ?q= 进来：转成一次搜索，再把 q 从地址栏去掉
-watch(
-  () => route.query.q,
-  value => {
-    if (typeof value !== 'string' || !value) return
-    searchText.value = value
-    useRouter().replace({ query: { ...route.query, q: undefined } })
-  },
-  { immediate: true }
-)
+// ?q= from another page (e.g. the settings top bar): run it as a search, then drop q from the URL.
+// The page is kept alive, so this runs on a fresh mount and on every return to /bookmarks;
+// hooks rather than a route watcher, so a cached instance never reacts to another page's URL.
+const consumeSearchQuery = () => {
+  const q = route.query.q
+  if (typeof q !== 'string' || !q) return
+  searchText.value = q
+  // Keep the current path: a name-based replace would turn the '/' alias into '/bookmarks' and remount the page
+  useRouter().replace({ path: route.path, query: { ...route.query, q: undefined } })
+}
+onMounted(consumeSearchQuery)
+onActivated(consumeSearchQuery)
 
 watch(searchText, value => {
   if (value) sourceFilter.value = null

--- a/apps/slax-reader-dweb/layers/core/app/pages/bookmarks/index.vue
+++ b/apps/slax-reader-dweb/layers/core/app/pages/bookmarks/index.vue
@@ -264,8 +264,8 @@ watch(filterStatus, (value, oldValue) => {
 // The page is kept alive, so this runs on a fresh mount and on every return to /bookmarks;
 // hooks rather than a route watcher, so a cached instance never reacts to another page's URL.
 const consumeSearchQuery = () => {
-  const q = route.query.q
-  if (typeof q !== 'string' || !q) return
+  const q = typeof route.query.q === 'string' ? route.query.q.trim() : ''
+  if (!q) return
   searchText.value = q
   // Keep the current path: a name-based replace would turn the '/' alias into '/bookmarks' and remount the page
   useRouter().replace({ path: route.path, query: { ...route.query, q: undefined } })

--- a/apps/slax-reader-dweb/layers/core/app/pages/user.vue
+++ b/apps/slax-reader-dweb/layers/core/app/pages/user.vue
@@ -2,8 +2,8 @@
   <div class="user-info">
     <NuxtLoadingIndicator color="var(--slax-accent)" />
 
-    <!-- 顶栏：与收件箱共用同一个顶栏，页面切换时头部不变 -->
-    <BookmarksTopBar @search="searchBookmarks" @feedback="feedbackClick" />
+    <!-- Same top bar as the inbox, so the header does not change shape between pages -->
+    <BookmarksTopBar :sidebar-toggle="false" @search="searchBookmarks" @feedback="feedbackClick" @check-all="showNotifications" />
 
     <div class="content">
       <Transition name="opacity" mode="out-in">
@@ -188,17 +188,23 @@ const getUserDetailInfo = async () => {
   loading.value = false
 }
 
-// 顶栏搜索：回到收件箱并带上关键词，收件箱页读到 q 后发起搜索
+// Top bar search: go to the inbox with the keyword; the inbox page turns ?q= into a search.
+// The clear (×) button emits '', which must not leave the settings page.
 const searchBookmarks = (keyword: string) => {
-  const text = keyword.trim()
-  navigateTo(text ? { path: '/bookmarks', query: { q: text } } : '/bookmarks')
+  if (!keyword) return
+  navigateTo({ path: '/bookmarks', query: { q: keyword } })
+}
+
+// "View all" in the bell popover: the list lives on the inbox page
+const showNotifications = () => {
+  navigateTo({ path: '/bookmarks', query: { filter: 'notifications' } })
 }
 
 const feedbackClick = () => {
   showFeedbackModal({
     reportType: 'parse_error',
     title: '',
-    email: userInfo.value?.email || userStore.userInfo?.email || '',
+    email: userInfo.value?.email || '',
     params: {
       entry_point: 'settings'
     }
@@ -243,7 +249,8 @@ const localeSelect = (index: number) => {
   padding: calc(var(--slax-header-height) + 16px) 24px 88px;
 
   @media (max-width: 768px) {
-    padding: calc(var(--slax-header-h-mobile) + 16px) 16px 88px;
+    padding-left: 16px;
+    padding-right: 16px;
   }
 }
 

--- a/apps/slax-reader-dweb/tests/unit/components/BookmarkList/BookmarksSearchBar.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/BookmarkList/BookmarksSearchBar.spec.ts
@@ -1,0 +1,43 @@
+// BookmarksSearchBar：顶栏搜索框
+// 关注点：回车搜索 / 清除 / 页面搜索词通过 search-text 同步进输入框
+import BookmarksSearchBar from '~~/layers/core/app/components/BookmarkList/BookmarksSearchBar.vue'
+
+import { mountWithApp } from '~~/tests/setup/mount'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('BookmarksSearchBar', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('emits the trimmed keyword on enter and nothing when empty', async () => {
+    const w = mountWithApp(BookmarksSearchBar)
+    const input = w.find('input.search-input')
+    await input.setValue('   ')
+    await input.trigger('keydown.enter')
+    expect(w.emitted('search')).toBeUndefined()
+    await input.setValue('  vue  ')
+    await input.trigger('keydown.enter')
+    expect(w.emitted('search')?.[0]).toEqual(['vue'])
+  })
+
+  it('emits an empty search from the clear button', async () => {
+    const w = mountWithApp(BookmarksSearchBar)
+    await w.find('input.search-input').setValue('vue')
+    await w.find('.search-clear').trigger('mousedown')
+    expect(w.emitted('search')?.[0]).toEqual([''])
+    expect((w.find('input.search-input').element as HTMLInputElement).value).toBe('')
+  })
+
+  it('follows the page search text: filled by ?q=, cleared on back', async () => {
+    const w = mountWithApp(BookmarksSearchBar, { props: { searchText: '' } })
+    const input = () => w.find('input.search-input').element as HTMLInputElement
+    await w.setProps({ searchText: 'rust' })
+    expect(input().value).toBe('rust')
+    await w.setProps({ searchText: '' })
+    expect(input().value).toBe('')
+    // Typing locally does not emit until enter
+    await w.find('input.search-input').setValue('go')
+    expect(w.emitted('search')).toBeUndefined()
+  })
+})

--- a/apps/slax-reader-dweb/tests/unit/components/BookmarkList/BookmarksTopBar.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/BookmarkList/BookmarksTopBar.spec.ts
@@ -7,8 +7,9 @@ import { useSidebarCollapsed } from '~~/layers/core/app/composables/bookmark/use
 import { mountWithApp } from '~~/tests/setup/mount'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-const mountTopBar = () =>
+const mountTopBar = (props: Record<string, unknown> = {}) =>
   mountWithApp(BookmarksTopBar, {
+    props,
     global: {
       stubs: {
         BookmarksSearchBar: true,
@@ -42,6 +43,12 @@ describe('BookmarksTopBar', () => {
     const btn = wrapper.find('.topbar-menu')
     expect(btn.attributes('aria-expanded')).toBe('false')
     expect(btn.attributes('title')).toBe('Expand sidebar')
+  })
+
+  it('sidebar-toggle=false 时不渲染 .topbar-menu，logo 仍在', () => {
+    const wrapper = mountTopBar({ sidebarToggle: false })
+    expect(wrapper.find('.topbar-menu').exists()).toBe(false)
+    expect(wrapper.find('.topbar-logo').exists()).toBe(true)
   })
 
   it('.topbar-menu 位于 logo 之前', () => {

--- a/apps/slax-reader-dweb/tests/unit/components/BookmarkList/TagChip.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/components/BookmarkList/TagChip.spec.ts
@@ -21,6 +21,13 @@ describe('components/BookmarkList/TagChip', () => {
     expect(w.find('.tag-ai').exists()).toBe(false)
     expect(w.find('.tag-act').exists()).toBe(false)
     expect(w.classes()).not.toContain('mine')
+    expect(w.classes()).not.toContain('has-acts')
+  })
+
+  it('reserves the action gutter only on chips that have actions', () => {
+    expect(mountWithApp(TagChip, { props: { tag, removable: true } }).classes()).toContain('has-acts')
+    expect(mountWithApp(TagChip, { props: { tag, promotable: true } }).classes()).toContain('has-acts')
+    expect(mountWithApp(TagChip, { props: { tag, count: 3 } }).classes()).not.toContain('has-acts')
   })
 
   it('emits click on the chip and remove on the × without click', async () => {

--- a/apps/slax-reader-dweb/tests/unit/pages/user.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/pages/user.spec.ts
@@ -75,11 +75,12 @@ afterEach(() => {
 
 // 子组件 stub，避免子组件内部副作用
 const stubs = {
-  // 与收件箱共用的顶栏：只保留 search / feedback 两个事件
+  // Top bar shared with the inbox: only the search / feedback events matter here
   BookmarksTopBar: {
     name: 'BookmarksTopBar',
     template: '<header class="bookmarks-topbar-stub"></header>',
-    emits: ['search', 'feedback']
+    props: ['sidebarToggle', 'searchText'],
+    emits: ['search', 'feedback', 'checkAll']
   },
   UserRelatedInfoSection: {
     name: 'UserRelatedInfoSection',
@@ -171,14 +172,28 @@ describe('pages/user', () => {
   })
 
   describe('共用顶栏', () => {
-    it('顶栏搜索 → 带 q 回到收件箱；空关键词只回收件箱', async () => {
+    it('顶栏不带侧栏折叠按钮', async () => {
+      const wrapper = mountWithApp(UserPage, { global: { stubs } })
+      await flushPromises()
+      expect(wrapper.findComponent({ name: 'BookmarksTopBar' }).props('sidebarToggle')).toBe(false)
+    })
+
+    it('顶栏搜索 → 带 q 回到收件箱；清空（空关键词）不离开设置页', async () => {
       const wrapper = mountWithApp(UserPage, { global: { stubs } })
       await flushPromises()
       const topbar = wrapper.findComponent({ name: 'BookmarksTopBar' })
-      await topbar.vm.$emit('search', '  vue  ')
+      await topbar.vm.$emit('search', 'vue')
       expect(mockNavigateTo).toHaveBeenCalledWith({ path: '/bookmarks', query: { q: 'vue' } })
-      await topbar.vm.$emit('search', '   ')
-      expect(mockNavigateTo).toHaveBeenLastCalledWith('/bookmarks')
+      mockNavigateTo.mockClear()
+      await topbar.vm.$emit('search', '')
+      expect(mockNavigateTo).not.toHaveBeenCalled()
+    })
+
+    it('通知“查看全部” → 跳到收件箱的通知列表', async () => {
+      const wrapper = mountWithApp(UserPage, { global: { stubs } })
+      await flushPromises()
+      await wrapper.findComponent({ name: 'BookmarksTopBar' }).vm.$emit('checkAll')
+      expect(mockNavigateTo).toHaveBeenCalledWith({ path: '/bookmarks', query: { filter: 'notifications' } })
     })
 
     it('顶栏反馈 → showFeedbackModal 带用户邮箱和 settings 入口', async () => {


### PR DESCRIPTION
## 改了什么

对 #284 复核后的修正，#284 已先合并。

- 设置页顶栏搜索框点 × 清空时会发出空关键词，原来会跳回收件箱；现在空关键词不做任何事。
- 收件箱读 `?q=` 原来用 route watcher，页面是 keep-alive 的，改为在 mount / activated 时读；去掉 `q` 时保留当前 path，避免 `/` 别名被替换成 `/bookmarks` 导致重挂载。
- 收件箱的搜索词通过 `search-text` 传到顶栏搜索框（BookmarksLayout → BookmarksTopBar → BookmarksSearchBar）：从设置页搜过来输入框里有词，退出搜索时输入框跟着清空。
- 顶栏加 `sidebar-toggle` 属性，设置页没有侧栏，不显示折叠按钮。铃铛“查看全部”在设置页跳到 `/bookmarks?filter=notifications`。
- 标签 chip 改为：有 ↑ / × 的 chip 常驻预留右侧留白，按钮放在留白里。不再盖住标签名或计数，短标签也不会误点成删除。按钮用 `visibility` 隐藏，键盘 Tab 能到。
- 反馈邮箱只取设置页自己拉的用户信息，不再同时读 store。

## 验证

- `tests/unit/pages/user.spec.ts`、`tests/unit/components/BookmarkList/**`（含新增 `BookmarksSearchBar.spec.ts`）、`BookmarksLayout.spec.ts` 共 18 个文件 180 项通过。
- 改动文件 ESLint 无 error，prettier 通过；vue-tsc 报错都是仓库既有，不在改动文件。
- 没有起浏览器实际看效果。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8AxYhZFV3PsCLm8gSMm68
