### PR TITLE
🐛 fix onboarding extension detection after install

### DIFF
--- a/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksOnboardingHero.vue
+++ b/apps/slax-reader-dweb/layers/core/app/components/BookmarkList/BookmarksOnboardingHero.vue
@@ -123,6 +123,8 @@ const gettingStartedUrl = 'https://slax.com/blog/built-an-open-source-tool-to-sa
 const { isInstalled } = useExtensionDetection()
 const { isPinned } = usePinnedDetection()
 const manualStep3 = ref(false)
+const installPending = ref(false)
+let installReturnTimer: ReturnType<typeof setTimeout> | undefined
 
 const currentStep = computed<1 | 2 | 3>(() => {
   if (manualStep3.value) return 3
@@ -131,7 +133,23 @@ const currentStep = computed<1 | 2 | 3>(() => {
   return 3
 })
 
-const install = () => window.open(pluginUrl)
+const checkInstallReturn = () => {
+  if (!installPending.value || document.visibilityState !== 'visible') return
+
+  if (installReturnTimer) clearTimeout(installReturnTimer)
+  installReturnTimer = setTimeout(() => {
+    installReturnTimer = undefined
+    if (!installPending.value) return
+
+    installPending.value = false
+    // 新安装的扩展不会自动注入已打开的页面，刷新后才能创建 DOM 标记并进入步骤 2
+    if (!isInstalled.value) window.location.reload()
+  }, 300)
+}
+const install = () => {
+  installPending.value = true
+  window.open(pluginUrl)
+}
 const confirmPinned = () => (manualStep3.value = true)
 const skip = () => emit('skip')
 const complete = () => emit('complete')
@@ -176,6 +194,9 @@ const playDemoSequence = () => {
 onMounted(() => {
   playDemoSequence()
 
+  document.addEventListener('visibilitychange', checkInstallReturn)
+  window.addEventListener('focus', checkInstallReturn)
+
   if (window.matchMedia) {
     reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
     reducedMotionQuery.addEventListener?.('change', playDemoSequence)
@@ -184,6 +205,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   clearTimers()
+  if (installReturnTimer) clearTimeout(installReturnTimer)
+  document.removeEventListener('visibilitychange', checkInstallReturn)
+  window.removeEventListener('focus', checkInstallReturn)
   reducedMotionQuery?.removeEventListener?.('change', playDemoSequence)
 })
 </script>

--- a/apps/slax-reader-dweb/layers/core/app/composables/useExtensionDetection.ts
+++ b/apps/slax-reader-dweb/layers/core/app/composables/useExtensionDetection.ts
@@ -11,31 +11,44 @@ export function useExtensionDetection() {
   onMounted(() => {
     const matchMarker = () => EXTENSION_MARKERS.some(tag => document.querySelector(tag))
 
-    if (matchMarker()) {
+    let observer: MutationObserver | undefined
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    const recheck = () => {
+      if (!matchMarker()) return
+
       isInstalled.value = true
       checked.value = true
+      observer?.disconnect()
+      if (timer) clearTimeout(timer)
+    }
+
+    if (matchMarker()) {
+      recheck()
       return
     }
 
     // 超时不代表停止监听，避免错过迟到的标记
-    const observer = new MutationObserver(() => {
-      if (matchMarker()) {
-        isInstalled.value = true
-        checked.value = true
-        observer.disconnect()
-        clearTimeout(timer)
-      }
-    })
+    observer = new MutationObserver(recheck)
     // 插入较深，须 subtree:true
     observer.observe(document.documentElement, { childList: true, subtree: true })
 
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       checked.value = true
     }, DETECTION_TIMEOUT)
 
+    // 扩展可能在当前页面切回可见后才完成注入，主动复查一次
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') recheck()
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    window.addEventListener('focus', recheck)
+
     onUnmounted(() => {
-      observer.disconnect()
-      clearTimeout(timer)
+      observer?.disconnect()
+      if (timer) clearTimeout(timer)
+      document.removeEventListener('visibilitychange', onVisible)
+      window.removeEventListener('focus', recheck)
     })
   })
 

--- a/apps/slax-reader-dweb/tests/unit/composables/useExtensionDetection.spec.ts
+++ b/apps/slax-reader-dweb/tests/unit/composables/useExtensionDetection.spec.ts
@@ -83,6 +83,31 @@ describe('useExtensionDetection', () => {
     })
   })
 
+  it('页面切回可见/重新获得焦点后主动复查扩展标记', async () => {
+    const panel = document.createElement('slax-reader-panel')
+    let markerAvailable = false
+    const originalQuerySelector = document.querySelector.bind(document)
+    const querySelectorSpy = vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+      if (selector === 'slax-reader-panel' || selector === 'slax-reader-modal') {
+        return selector === 'slax-reader-panel' && markerAvailable ? panel : null
+      }
+      return originalQuerySelector(selector)
+    })
+
+    const { api } = mountDetection()
+    expect(api.isInstalled.value).toBe(false)
+
+    // 模拟从扩展商店页面切回 onboarding 页面
+    markerAvailable = true
+    window.dispatchEvent(new Event('focus'))
+
+    await vi.waitFor(() => {
+      expect(api.isInstalled.value).toBe(true)
+      expect(api.checked.value).toBe(true)
+    })
+    querySelectorSpy.mockRestore()
+  })
+
   it('组件卸载时清理 observer/timer，不再触发状态变更', () => {
     vi.useFakeTimers()
     const { wrapper, api } = mountDetection()


### PR DESCRIPTION
## Summary
- recheck extension markers when onboarding returns to the foreground
- refresh once after installation when the content script is not yet injected
- add regression coverage for focus-based detection

## Validation
- extension detection tests pass
- vue-tsc passes
- eslint passes

## Related
- consumed by frontend PR: https://github.com/unnoo/slax_reader_frontend/pull/1570